### PR TITLE
Show the model name, and request info if possible, on error

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -10,8 +10,8 @@ import types
 from pathlib import Path
 from typing import Any, Generator, Optional, Sequence, TypeVar
 
-import litellm
 import httpx
+import litellm
 import yaml
 from jinja2 import (
     Environment,


### PR DESCRIPTION
A minor change to include the model name when reporting model failures.

If the failure is due to network connectivity, the output now includes that.  Where before we logged 
```
basic.pdl:4 - Error during model call: ConnectError('[Errno 61] Connection refused')
```

we now show
```
basic.pdl:4 - model 'ollama/granite-code:8b' encountered ConnectError('[Errno 61] Connection refused') trying to POST against http://localhost:11434/api/generate
```