### PR TITLE
Set default params for Watsonx chat & text models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "jinja2~=3.0",
   "PyYAML~=6.0",
   "jsonschema~=4.0",
-  "litellm>=1.54",
+  "litellm>=1.59.6",
   "termcolor~=2.0",
   "ipython~=8.0",
 ]

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -581,7 +581,12 @@ def get_default_model_parameters() -> list[dict[str, Any]]:
     """Model-specific defaults to apply"""
     return [
         {
-            "*watsonx*": {
+            "*watsonx/*": {
+                "temperature": 0,
+            },
+        },
+        {
+            "*watsonx_text*": {
                 "decoding_method": DECODING_METHOD,
                 "max_tokens": MAX_NEW_TOKENS,
                 "min_new_tokens": MIN_NEW_TOKENS,


### PR DESCRIPTION
As of LiteLLM 1.52.1, model prefix `watsonx/` points to the `/chat` endpoint. See change [here](https://github.com/BerriAI/litellm/commit/5c5527074045aa1e0ed90f2aaf02f38402e758e9#diff-1f5c142ba9c5f1b4e12d2bb8bf20fc82e84fb33e02846c9cd99fd281e4a4a800R2623). This endpoint has several differences in accepted [parameters](https://cloud.ibm.com/apidocs/watsonx-ai#text-chat-request), and more sane defaults. It supports `json_object` as a `response_format`, and the endpoint supports tool calling (future work for PDL). Rather than handle different LiteLLM dependency versions pointing to different APIs, this PR also bumps the minimum LiteLLM version needed. One thing to note, `set_default_granite_model_parameters` is only called for granite models of course. This means that using Granite, the default will be greedy decoding/temp = 0, and for any other model, the default is temp = 1. That could be a surprising difference in behavior.