### PR TITLE
Config options for model default parameters

### DIFF
--- a/src/pdl/pdl.py
+++ b/src/pdl/pdl.py
@@ -235,9 +235,7 @@ def main():
         exec_docker(*args)
         assert False  # unreachable: exec_docker terminate the execution
 
-    initial_scope = {
-        "pdl_model_default_parameters": get_default_model_parameters()
-    }
+    initial_scope = {"pdl_model_default_parameters": get_default_model_parameters()}
     if args.data_file is not None:
         with open(args.data_file, "r", encoding="utf-8") as scope_fp:
             initial_scope = yaml.safe_load(scope_fp)

--- a/src/pdl/pdl.py
+++ b/src/pdl/pdl.py
@@ -17,10 +17,12 @@ from .pdl_ast import (
     RoleType,
     ScopeType,
     empty_block_location,
+    get_default_model_parameters,
 )
 from .pdl_interpreter import InterpreterState, process_prog
 from .pdl_parser import parse_file, parse_str
 from .pdl_runner import exec_docker
+from .pdl_utils import validate_scope
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +165,7 @@ def main():
         "-f",
         "--data-file",
         dest="data_file",
-        help="file containing initial values to add to the scope",
+        help="YAML file containing initial values to add to the scope",
     )
     parser.add_argument(
         "-d",
@@ -233,12 +235,15 @@ def main():
         exec_docker(*args)
         assert False  # unreachable: exec_docker terminate the execution
 
-    initial_scope = {}
+    initial_scope = {
+        "pdl_model_default_parameters": get_default_model_parameters()
+    }
     if args.data_file is not None:
         with open(args.data_file, "r", encoding="utf-8") as scope_fp:
             initial_scope = yaml.safe_load(scope_fp)
     if args.data is not None:
         initial_scope = initial_scope | yaml.safe_load(args.data)
+    validate_scope(initial_scope)
 
     match args.stream:
         case "result":

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -571,47 +571,53 @@ def set_structured_decoding_parameters(
 def get_default_model_parameters() -> list[dict[str, Any]]:
     """Model-specific defaults to apply"""
     return [
-        { "*watsonx*": {
-            "decoding_method": DECODING_METHOD,
-            "max_tokens": MAX_NEW_TOKENS,
-            "min_new_tokens": MIN_NEW_TOKENS,
-            "repetition_penalty": REPETITION_PENALTY,
-          },
-        },
-        { "replicate*granite-3.0*": {
-            "temperature": 0,
-            "roles": {
-                "system": {
-                    "pre_message": "<|start_of_role|>system<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "user": {
-                    "pre_message": "<|start_of_role|>user<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "assistant": {
-                    "pre_message": "<|start_of_role|>assistant<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "available_tools": {
-                    "pre_message": "<|start_of_role|>available_tools<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "tool_response": {
-                    "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
+        {
+            "*watsonx*": {
+                "decoding_method": DECODING_METHOD,
+                "max_tokens": MAX_NEW_TOKENS,
+                "min_new_tokens": MIN_NEW_TOKENS,
+                "repetition_penalty": REPETITION_PENALTY,
             },
-            "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>"
-          }
-        }]
+        },
+        {
+            "replicate*granite-3.0*": {
+                "temperature": 0,
+                "roles": {
+                    "system": {
+                        "pre_message": "<|start_of_role|>system<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "user": {
+                        "pre_message": "<|start_of_role|>user<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "assistant": {
+                        "pre_message": "<|start_of_role|>assistant<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "available_tools": {
+                        "pre_message": "<|start_of_role|>available_tools<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "tool_response": {
+                        "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                },
+                "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>",
+            }
+        },
+    ]
+
 
 def get_sampling_defaults() -> list[dict[str, Any]]:
     """Model-specific defaults to apply if we are sampling."""
     return [
-        { "*": {
-            "temperature": TEMPERATURE_SAMPLING,
-            "top_k": TOP_K_SAMPLING,
-            "top_p": TOP_P_SAMPLING,
+        {
+            "*": {
+                "temperature": TEMPERATURE_SAMPLING,
+                "top_k": TOP_K_SAMPLING,
+                "top_p": TOP_P_SAMPLING,
+            }
         }
-    }]
+    ]

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -542,7 +542,7 @@ class PDLException(Exception):
 
 MAX_NEW_TOKENS = 1024
 MIN_NEW_TOKENS = 1
-REPETITION_PENATLY = 1.05
+REPETITION_PENALTY = 1.05
 TEMPERATURE_SAMPLING = 0.7
 TOP_P_SAMPLING = 0.85
 TOP_K_SAMPLING = 50
@@ -568,49 +568,19 @@ def set_structured_decoding_parameters(
     return parameters
 
 
-def set_default_granite_model_parameters(
-    model_id: str,
-    spec: Any,
-    parameters: Optional[dict[str, Any]],
-) -> dict[str, Any]:
-    if parameters is None:
-        parameters = {}
-
-    if "watsonx" in model_id:
-        if "decoding_method" not in parameters:
-            parameters["decoding_method"] = (
-                DECODING_METHOD  # pylint: disable=attribute-defined-outside-init
-            )
-        if "max_tokens" in parameters and parameters["max_tokens"] is None:
-            parameters["max_tokens"] = (
-                MAX_NEW_TOKENS  # pylint: disable=attribute-defined-outside-init
-            )
-        if "min_new_tokens" not in parameters:
-            parameters["min_new_tokens"] = (
-                MIN_NEW_TOKENS  # pylint: disable=attribute-defined-outside-init
-            )
-        if "repetition_penalty" not in parameters:
-            parameters["repetition_penalty"] = (
-                REPETITION_PENATLY  # pylint: disable=attribute-defined-outside-init
-            )
-        if parameters["decoding_method"] == "sample":
-            if "temperature" not in parameters:
-                parameters["temperature"] = (
-                    TEMPERATURE_SAMPLING  # pylint: disable=attribute-defined-outside-init
-                )
-            if "top_k" not in parameters:
-                parameters["top_k"] = (
-                    TOP_K_SAMPLING  # pylint: disable=attribute-defined-outside-init
-                )
-            if "top_p" not in parameters:
-                parameters["top_p"] = (
-                    TOP_P_SAMPLING  # pylint: disable=attribute-defined-outside-init
-                )
-    if "replicate" in model_id and "granite-3.0" in model_id:
-        if "temperature" not in parameters or parameters["temperature"] is None:
-            parameters["temperature"] = 0  # setting to decoding greedy
-        if "roles" not in parameters:
-            parameters["roles"] = {
+def get_default_model_parameters() -> list[dict[str, Any]]:
+    """Model-specific defaults to apply"""
+    return [
+        { "*watsonx*": {
+            "decoding_method": DECODING_METHOD,
+            "max_tokens": MAX_NEW_TOKENS,
+            "min_new_tokens": MIN_NEW_TOKENS,
+            "repetition_penalty": REPETITION_PENALTY,
+          },
+        },
+        { "replicate*granite-3.0*": {
+            "temperature": 0,
+            "roles": {
                 "system": {
                     "pre_message": "<|start_of_role|>system<|end_of_role|>",
                     "post_message": "<|end_of_text|>",
@@ -631,10 +601,17 @@ def set_default_granite_model_parameters(
                     "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
                     "post_message": "<|end_of_text|>",
                 },
-            }
-        if "final_prompt_value" not in parameters:
-            parameters["final_prompt_value"] = (
-                "<|start_of_role|>assistant<|end_of_role|>"
-            )
+            },
+            "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>"
+          }
+        }]
 
-    return parameters
+def get_sampling_defaults() -> list[dict[str, Any]]:
+    """Model-specific defaults to apply if we are sampling."""
+    return [
+        { "*": {
+            "temperature": TEMPERATURE_SAMPLING,
+            "top_k": TOP_K_SAMPLING,
+            "top_p": TOP_P_SAMPLING,
+        }
+    }]

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1115,19 +1115,20 @@ def step_call_model(
         litellm_params = {}
 
         def get_transformed_inputs(kwargs):
-            # Apply PDL defaults to model invocation
-            kwargs["optional_params"] = apply_defaults(
-                kwargs["model"],
-                kwargs["optional_params"],
-                scope["pdl_model_default_parameters"],
-            )
-
             params_to_model = kwargs["additional_args"]["complete_input_dict"]
             nonlocal litellm_params
             litellm_params = params_to_model
 
         litellm.input_callback = [get_transformed_inputs]
         # append_log(state, "Model Input", messages_to_str(model_input))
+
+        # Apply PDL defaults to model invocation
+        print(f"@@@ ecs before applying defaults, concrete_block.parameters is a {type(concrete_block.parameters)}")
+        concrete_block.parameters = apply_defaults(
+            concrete_block.model,
+            concrete_block.parameters,
+            scope["pdl_model_default_parameters"],
+        )
 
         msg, raw_result = yield from generate_client_response(
             state, concrete_block, model_input

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -89,6 +89,7 @@ from .pdl_utils import (  # noqa: E402
     messages_concat,
     replace_contribute_value,
     stringify,
+    apply_defaults,
 )
 
 logger = logging.getLogger(__name__)
@@ -1114,6 +1115,11 @@ def step_call_model(
         litellm_params = {}
 
         def get_transformed_inputs(kwargs):
+            # Apply PDL defaults to model invocation
+            kwargs['optional_params'] = apply_defaults(kwargs['model'],
+                                                       kwargs['optional_params'],
+                                                       scope['pdl_model_default_parameters'])
+
             params_to_model = kwargs["additional_args"]["complete_input_dict"]
             nonlocal litellm_params
             litellm_params = params_to_model

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1123,12 +1123,12 @@ def step_call_model(
         # append_log(state, "Model Input", messages_to_str(model_input))
 
         # Apply PDL defaults to model invocation
-        print(f"@@@ ecs before applying defaults, concrete_block.parameters is a {type(concrete_block.parameters)}")
-        concrete_block.parameters = apply_defaults(
-            concrete_block.model,
-            concrete_block.parameters,
-            scope["pdl_model_default_parameters"],
-        )
+        if isinstance(concrete_block.parameters, dict):
+            concrete_block.parameters = apply_defaults(
+                str(concrete_block.model),
+                concrete_block.parameters,
+                scope["pdl_model_default_parameters"],
+            )
 
         msg, raw_result = yield from generate_client_response(
             state, concrete_block, model_input

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -85,11 +85,11 @@ from .pdl_scheduler import (  # noqa: E402
 )
 from .pdl_schema_validator import type_check_args, type_check_spec  # noqa: E402
 from .pdl_utils import (  # noqa: E402
+    apply_defaults,
     get_contribute_value,
     messages_concat,
     replace_contribute_value,
     stringify,
-    apply_defaults,
 )
 
 logger = logging.getLogger(__name__)
@@ -1116,9 +1116,11 @@ def step_call_model(
 
         def get_transformed_inputs(kwargs):
             # Apply PDL defaults to model invocation
-            kwargs['optional_params'] = apply_defaults(kwargs['model'],
-                                                       kwargs['optional_params'],
-                                                       scope['pdl_model_default_parameters'])
+            kwargs["optional_params"] = apply_defaults(
+                kwargs["model"],
+                kwargs["optional_params"],
+                scope["pdl_model_default_parameters"],
+            )
 
             params_to_model = kwargs["additional_args"]["complete_input_dict"]
             nonlocal litellm_params

--- a/src/pdl/pdl_llms.py
+++ b/src/pdl/pdl_llms.py
@@ -7,7 +7,6 @@ from litellm import completion
 
 from .pdl_ast import (
     Message,
-    set_default_granite_model_parameters,
     set_structured_decoding_parameters,
 )
 from .pdl_utils import remove_none_values_from_message
@@ -38,10 +37,6 @@ class LitellmModel:
         spec: Any,
         parameters: dict[str, Any],
     ) -> tuple[Message, Any]:
-        if "granite" in model_id and "granite-20b-code-instruct-r1.1" not in model_id:
-            parameters = set_default_granite_model_parameters(
-                model_id, spec, parameters
-            )
         parameters = set_structured_decoding_parameters(spec, parameters)
         if parameters.get("mock_response") is not None:
             litellm.suppress_debug_info = True
@@ -63,10 +58,6 @@ class LitellmModel:
         spec: Any,
         parameters: dict[str, Any],
     ) -> Generator[Message, Any, Any]:
-        if "granite" in model_id and "granite-20b-code-instruct-r1.1" not in model_id:
-            parameters = set_default_granite_model_parameters(
-                model_id, spec, parameters
-            )
         parameters = set_structured_decoding_parameters(spec, parameters)
         response = completion(
             model=model_id,

--- a/src/pdl/pdl_llms.py
+++ b/src/pdl/pdl_llms.py
@@ -5,10 +5,7 @@ import litellm
 from dotenv import load_dotenv
 from litellm import completion
 
-from .pdl_ast import (
-    Message,
-    set_structured_decoding_parameters,
-)
+from .pdl_ast import Message, set_structured_decoding_parameters
 from .pdl_utils import remove_none_values_from_message
 
 # Load environment variables

--- a/src/pdl/pdl_utils.py
+++ b/src/pdl/pdl_utils.py
@@ -2,7 +2,14 @@ import fnmatch
 import json
 from typing import Any, Sequence
 
-from .pdl_ast import ContributeTarget, ContributeValue, FunctionBlock, Message, Messages, get_sampling_defaults
+from .pdl_ast import (
+    ContributeTarget,
+    ContributeValue,
+    FunctionBlock,
+    Message,
+    Messages,
+    get_sampling_defaults,
+)
 
 
 def stringify(result):
@@ -85,7 +92,12 @@ def remove_none_values_from_message(message: Any) -> dict[str, Any]:
                 ret[key] = value
     return ret
 
-def apply_defaults(model_id: str, params: dict[str, Any], all_model_defaults: list[dict[str, dict[str, Any]]]) -> dict[str, Any]:
+
+def apply_defaults(
+    model_id: str,
+    params: dict[str, Any],
+    all_model_defaults: list[dict[str, dict[str, Any]]],
+) -> dict[str, Any]:
     # Never apply defaults to granite-20b-code-instruct-r1.1
     if "granite-20b-code-instruct-r1.1" in model_id:
         return params
@@ -97,7 +109,12 @@ def apply_defaults(model_id: str, params: dict[str, Any], all_model_defaults: li
 
     return parameters
 
-def apply_raw_defaults(model_id: str, params: dict[str, Any], model_defaults: list[dict[str, dict[str, Any]]]) -> dict[str, Any]:
+
+def apply_raw_defaults(
+    model_id: str,
+    params: dict[str, Any],
+    model_defaults: list[dict[str, dict[str, Any]]],
+) -> dict[str, Any]:
     """Apply defaults to params based on a list of model defaults
 
     Args:
@@ -120,7 +137,9 @@ def apply_raw_defaults(model_id: str, params: dict[str, Any], model_defaults: li
         assert isinstance(model_default, dict)
         for model_glob, glob_defaults in model_default.items():
             if not isinstance(glob_defaults, dict):
-                raise ValueError(f"invalid default type {type(glob_defaults)} for model matcher {model_glob}")
+                raise ValueError(
+                    f"invalid default type {type(glob_defaults)} for model matcher {model_glob}"
+                )
             assert isinstance(glob_defaults, dict)
             if fnmatch.fnmatchcase(model_id, model_glob):
                 print(f"model {model_id} matches {model_glob}")
@@ -134,17 +153,20 @@ def apply_raw_defaults(model_id: str, params: dict[str, Any], model_defaults: li
             retval[k] = v
     return retval
 
+
 def validate_scope(scope: dict):
     """Throw an exception if any key in scope is invalid"""
     validate_pdl_model_defaults(scope["pdl_model_default_parameters"])
 
+
 def validate_pdl_model_defaults(model_defaults: list[dict[str, dict[str, Any]]]):
     """Throw an exception if the model_defaults is not in expected format"""
 
-    errors = False
     for model_default in model_defaults:
         assert isinstance(model_default, dict)
         for model_glob, glob_defaults in model_default.items():
             if not isinstance(glob_defaults, dict):
-                raise ValueError(f"invalid defaults {glob_defaults} for model matcher {model_glob}")
+                raise ValueError(
+                    f"invalid defaults {glob_defaults} for model matcher {model_glob}"
+                )
             assert isinstance(glob_defaults, dict)

--- a/src/pdl/pdl_utils.py
+++ b/src/pdl/pdl_utils.py
@@ -126,9 +126,11 @@ def apply_raw_defaults(
         The parameters to send to the LLM
     """
 
-    assert isinstance(model_id, str)
-    assert isinstance(params, dict)
-    assert isinstance(model_defaults, list)
+    assert isinstance(model_id, str), f"model_id is a {type(model_id)}"
+    assert params is None or isinstance(params, dict), f"params is a {type(params)}"
+    assert isinstance(
+        model_defaults, list
+    ), f"model_defaults is a {type(model_defaults)}"
 
     # Construct defaults for this model.  If more than one set of default
     # applies, the last seen default "wins".
@@ -142,12 +144,12 @@ def apply_raw_defaults(
                 )
             assert isinstance(glob_defaults, dict)
             if fnmatch.fnmatchcase(model_id, model_glob):
-                print(f"model {model_id} matches {model_glob}")
+                # print(f"model {model_id} matches {model_glob}, applying {glob_defaults}")
                 for k, v in glob_defaults.items():
                     default_union[k] = v
 
     # Apply final list of defaults to explicit parameters
-    retval = dict(params)
+    retval = {} if params is None else dict(params)
     for k, v in default_union.items():
         if k not in retval or retval[k] is None:
             retval[k] = v

--- a/src/pdl/pdl_utils.py
+++ b/src/pdl/pdl_utils.py
@@ -1,7 +1,8 @@
+import fnmatch
 import json
 from typing import Any, Sequence
 
-from .pdl_ast import ContributeTarget, ContributeValue, FunctionBlock, Message, Messages
+from .pdl_ast import ContributeTarget, ContributeValue, FunctionBlock, Message, Messages, get_sampling_defaults
 
 
 def stringify(result):
@@ -83,3 +84,67 @@ def remove_none_values_from_message(message: Any) -> dict[str, Any]:
             else:
                 ret[key] = value
     return ret
+
+def apply_defaults(model_id: str, params: dict[str, Any], all_model_defaults: list[dict[str, dict[str, Any]]]) -> dict[str, Any]:
+    # Never apply defaults to granite-20b-code-instruct-r1.1
+    if "granite-20b-code-instruct-r1.1" in model_id:
+        return params
+
+    parameters = apply_raw_defaults(model_id, params, all_model_defaults)
+
+    if "decoding_method" in parameters and parameters["decoding_method"] == "sample":
+        parameters = apply_raw_defaults(model_id, parameters, get_sampling_defaults())
+
+    return parameters
+
+def apply_raw_defaults(model_id: str, params: dict[str, Any], model_defaults: list[dict[str, dict[str, Any]]]) -> dict[str, Any]:
+    """Apply defaults to params based on a list of model defaults
+
+    Args:
+        model_id: A PDL model ID
+        params: The explicit parameters set by in PDL
+        model_defaults: A list of dicts, where the keys are globs for model id, and the value is a dict of defaults
+
+    Returns:
+        The parameters to send to the LLM
+    """
+
+    assert isinstance(model_id, str)
+    assert isinstance(params, dict)
+    assert isinstance(model_defaults, list)
+
+    # Construct defaults for this model.  If more than one set of default
+    # applies, the last seen default "wins".
+    default_union = {}
+    for model_default in model_defaults:
+        assert isinstance(model_default, dict)
+        for model_glob, glob_defaults in model_default.items():
+            if not isinstance(glob_defaults, dict):
+                raise ValueError(f"invalid default type {type(glob_defaults)} for model matcher {model_glob}")
+            assert isinstance(glob_defaults, dict)
+            if fnmatch.fnmatchcase(model_id, model_glob):
+                print(f"model {model_id} matches {model_glob}")
+                for k, v in glob_defaults.items():
+                    default_union[k] = v
+
+    # Apply final list of defaults to explicit parameters
+    retval = dict(params)
+    for k, v in default_union.items():
+        if k not in retval or retval[k] is None:
+            retval[k] = v
+    return retval
+
+def validate_scope(scope: dict):
+    """Throw an exception if any key in scope is invalid"""
+    validate_pdl_model_defaults(scope["pdl_model_default_parameters"])
+
+def validate_pdl_model_defaults(model_defaults: list[dict[str, dict[str, Any]]]):
+    """Throw an exception if the model_defaults is not in expected format"""
+
+    errors = False
+    for model_default in model_defaults:
+        assert isinstance(model_default, dict)
+        for model_glob, glob_defaults in model_default.items():
+            if not isinstance(glob_defaults, dict):
+                raise ValueError(f"invalid defaults {glob_defaults} for model matcher {model_glob}")
+            assert isinstance(glob_defaults, dict)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,115 @@
+from pdl.pdl_utils import apply_defaults
+from pdl.pdl_ast import get_default_model_parameters
+
+def test_default_model_params_empty():
+    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
+                            {}, 
+                            [])
+    assert {} == params
+
+def test_default_model_params_nomatch():
+    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
+                            {}, 
+                            [
+                                {"dummy": {"foo": "bar"}}
+                            ])
+    assert {} == params
+
+def test_default_model_params_exact_match():
+    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
+                            {
+                                "foo": "baz"
+                            }, 
+                            [
+                                {"replicate/ibm-granite/granite-20b-code-instruct-8k":
+                                    {
+                                        "foo": "bar",
+                                        "max_tokens": 9999,
+                                    }
+                                }
+                            ])
+    assert {
+        "foo": "baz",
+        "max_tokens": 9999
+    } == params
+
+def test_default_model_params_partial_matches():
+    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
+                            {
+                                "foo": "baz"
+                            }, 
+                            [
+                                {
+                                    "*granite*":
+                                        {
+                                            "foo": "bar",
+                                            "max_tokens": 9999,
+                                        },
+                                },{
+                                    "*instruct-8k*":
+                                        {
+                                            "fruit": "banana",
+                                            "max_tokens": 777,
+                                        }
+                                },{
+                                    "*destruct-401k*":
+                                        {
+                                            "vegetable": "carrot",
+                                            "max_tokens": 888,
+                                        }
+                                }
+                            ])
+    assert {
+        "foo": "baz",
+        "fruit": "banana",
+        "max_tokens": 777
+    } == params
+
+def test_default_model_params():
+    model_defaults = get_default_model_parameters()
+    # No defaults for this model
+    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k",
+                            {},
+                            model_defaults)
+    assert {
+    } == params
+
+    # Granite-3.0 defaults for this model
+    params = apply_defaults("replicate/ibm-granite/granite-3.0-8b-instruct",
+                            {},
+                            model_defaults)
+    assert {
+        "temperature": 0,
+        "roles": {
+                "system": {
+                    "pre_message": "<|start_of_role|>system<|end_of_role|>",
+                    "post_message": "<|end_of_text|>",
+                },
+                "user": {
+                    "pre_message": "<|start_of_role|>user<|end_of_role|>",
+                    "post_message": "<|end_of_text|>",
+                },
+                "assistant": {
+                    "pre_message": "<|start_of_role|>assistant<|end_of_role|>",
+                    "post_message": "<|end_of_text|>",
+                },
+                "available_tools": {
+                    "pre_message": "<|start_of_role|>available_tools<|end_of_role|>",
+                    "post_message": "<|end_of_text|>",
+                },
+                "tool_response": {
+                    "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
+                    "post_message": "<|end_of_text|>",
+                },
+            },
+        "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>"
+    } == params
+
+def test_default_not_granite_20b_code_instruct_r1_1():
+    # Don't apply defaults to granite-20b-code-instruct-r1.1
+    model_defaults = get_default_model_parameters()
+    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-r1.1",
+                            {},
+                            model_defaults)
+    assert {
+    } == params

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,115 +1,111 @@
-from pdl.pdl_utils import apply_defaults
 from pdl.pdl_ast import get_default_model_parameters
+from pdl.pdl_utils import apply_defaults
+
 
 def test_default_model_params_empty():
-    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
-                            {}, 
-                            [])
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-20b-code-instruct-8k", {}, []
+    )
     assert {} == params
+
 
 def test_default_model_params_nomatch():
-    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
-                            {}, 
-                            [
-                                {"dummy": {"foo": "bar"}}
-                            ])
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-20b-code-instruct-8k",
+        {},
+        [{"dummy": {"foo": "bar"}}],
+    )
     assert {} == params
 
+
 def test_default_model_params_exact_match():
-    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
-                            {
-                                "foo": "baz"
-                            }, 
-                            [
-                                {"replicate/ibm-granite/granite-20b-code-instruct-8k":
-                                    {
-                                        "foo": "bar",
-                                        "max_tokens": 9999,
-                                    }
-                                }
-                            ])
-    assert {
-        "foo": "baz",
-        "max_tokens": 9999
-    } == params
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-20b-code-instruct-8k",
+        {"foo": "baz"},
+        [
+            {
+                "replicate/ibm-granite/granite-20b-code-instruct-8k": {
+                    "foo": "bar",
+                    "max_tokens": 9999,
+                }
+            }
+        ],
+    )
+    assert {"foo": "baz", "max_tokens": 9999} == params
+
 
 def test_default_model_params_partial_matches():
-    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k", 
-                            {
-                                "foo": "baz"
-                            }, 
-                            [
-                                {
-                                    "*granite*":
-                                        {
-                                            "foo": "bar",
-                                            "max_tokens": 9999,
-                                        },
-                                },{
-                                    "*instruct-8k*":
-                                        {
-                                            "fruit": "banana",
-                                            "max_tokens": 777,
-                                        }
-                                },{
-                                    "*destruct-401k*":
-                                        {
-                                            "vegetable": "carrot",
-                                            "max_tokens": 888,
-                                        }
-                                }
-                            ])
-    assert {
-        "foo": "baz",
-        "fruit": "banana",
-        "max_tokens": 777
-    } == params
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-20b-code-instruct-8k",
+        {"foo": "baz"},
+        [
+            {
+                "*granite*": {
+                    "foo": "bar",
+                    "max_tokens": 9999,
+                },
+            },
+            {
+                "*instruct-8k*": {
+                    "fruit": "banana",
+                    "max_tokens": 777,
+                }
+            },
+            {
+                "*destruct-401k*": {
+                    "vegetable": "carrot",
+                    "max_tokens": 888,
+                }
+            },
+        ],
+    )
+    assert {"foo": "baz", "fruit": "banana", "max_tokens": 777} == params
+
 
 def test_default_model_params():
     model_defaults = get_default_model_parameters()
     # No defaults for this model
-    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-8k",
-                            {},
-                            model_defaults)
-    assert {
-    } == params
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-20b-code-instruct-8k", {}, model_defaults
+    )
+    assert {} == params
 
     # Granite-3.0 defaults for this model
-    params = apply_defaults("replicate/ibm-granite/granite-3.0-8b-instruct",
-                            {},
-                            model_defaults)
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-3.0-8b-instruct", {}, model_defaults
+    )
     assert {
         "temperature": 0,
         "roles": {
-                "system": {
-                    "pre_message": "<|start_of_role|>system<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "user": {
-                    "pre_message": "<|start_of_role|>user<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "assistant": {
-                    "pre_message": "<|start_of_role|>assistant<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "available_tools": {
-                    "pre_message": "<|start_of_role|>available_tools<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
-                "tool_response": {
-                    "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
-                    "post_message": "<|end_of_text|>",
-                },
+            "system": {
+                "pre_message": "<|start_of_role|>system<|end_of_role|>",
+                "post_message": "<|end_of_text|>",
             },
-        "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>"
+            "user": {
+                "pre_message": "<|start_of_role|>user<|end_of_role|>",
+                "post_message": "<|end_of_text|>",
+            },
+            "assistant": {
+                "pre_message": "<|start_of_role|>assistant<|end_of_role|>",
+                "post_message": "<|end_of_text|>",
+            },
+            "available_tools": {
+                "pre_message": "<|start_of_role|>available_tools<|end_of_role|>",
+                "post_message": "<|end_of_text|>",
+            },
+            "tool_response": {
+                "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
+                "post_message": "<|end_of_text|>",
+            },
+        },
+        "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>",
     } == params
+
 
 def test_default_not_granite_20b_code_instruct_r1_1():
     # Don't apply defaults to granite-20b-code-instruct-r1.1
     model_defaults = get_default_model_parameters()
-    params = apply_defaults("replicate/ibm-granite/granite-20b-code-instruct-r1.1",
-                            {},
-                            model_defaults)
-    assert {
-    } == params
+    params = apply_defaults(
+        "replicate/ibm-granite/granite-20b-code-instruct-r1.1", {}, model_defaults
+    )
+    assert {} == params


### PR DESCRIPTION
Resolves #200

Introduces configuration for model parameter defaults.

Model parameter defaults can be changed with the `--data-file` option.  For example, `pdl --data-file model_defaults.yaml hello4.pdl `.

[model_defaults.yaml.txt](https://github.com/user-attachments/files/18459576/model_defaults.yaml.txt)
