### PR TITLE
fix: clean up react viewer to avoid use of non-components

### DIFF
--- a/pdl-live-react/src/view/transcript/Array.tsx
+++ b/pdl-live-react/src/view/transcript/Array.tsx
@@ -1,4 +1,4 @@
-import show_block from "./Block"
+import Block from "./Block"
 
 import Context, { withIter } from "../../Context"
 import { type PdlBlock } from "../../pdl_ast"
@@ -8,16 +8,14 @@ type Props = {
   ctx: Context
 }
 
-export default function show_array({ array, ctx }: Props) {
+export default function Array({ array, ctx }: Props) {
   return (
     <>
       <pre>{"["}</pre>
-      {array.flatMap((block, idx) =>
-        [
-          <div key={idx}>{show_block(block, withIter(ctx, idx))}</div>,
-          idx < array.length - 1 && <pre>,</pre>,
-        ].filter(Boolean),
-      )}
+      {array.flatMap((block, idx) => [
+        <Block key={idx} data={block} ctx={withIter(ctx, idx)} />,
+        idx < array.length - 1 && <pre>,</pre>,
+      ])}
       <pre>{"]"}</pre>
     </>
   )

--- a/pdl-live-react/src/view/transcript/Blocks.tsx
+++ b/pdl-live-react/src/view/transcript/Blocks.tsx
@@ -1,15 +1,18 @@
 import { type ReactElement } from "react"
 
-import show_block_conjoin from "./BlocksConjoin"
+import BlocksConjoin from "./BlocksConjoin"
 
 import Context, { withIter } from "../../Context"
 import { isPdlBlock, type PdlBlock } from "../../helpers"
 
-export default function show_blocks(
-  blocks: (ReactElement | PdlBlock)[],
-  ctx: Context,
-) {
+type Props = { blocks: (ReactElement | PdlBlock)[]; ctx: Context }
+
+export default function Blocks({ blocks, ctx }: Props) {
   return blocks.flatMap((block, idx) =>
-    !isPdlBlock(block) ? block : show_block_conjoin(block, withIter(ctx, idx)),
+    !isPdlBlock(block) ? (
+      block
+    ) : (
+      <BlocksConjoin key={idx} block={block} ctx={withIter(ctx, idx)} />
+    ),
   )
 }

--- a/pdl-live-react/src/view/transcript/BlocksConjoin.tsx
+++ b/pdl-live-react/src/view/transcript/BlocksConjoin.tsx
@@ -1,11 +1,15 @@
-import show_block from "./Block"
+import Block from "./Block"
 import Context, { withId } from "../../Context"
 import { isTextBlockWithArrayContent, type PdlBlock } from "../../helpers"
 
-export default function show_block_conjoin(block: PdlBlock, ctx: Context) {
+type Props = { block: PdlBlock; ctx: Context }
+
+export default function BlocksConjoin({ block, ctx }: Props) {
   if (isTextBlockWithArrayContent(block)) {
-    return block.text.flatMap((b, idx) => show_block(b, withId(ctx, idx)))
+    return block.text.map((b, idx) => (
+      <Block key={idx} data={b} ctx={withId(ctx, idx)} />
+    ))
   } else {
-    return [show_block(block, ctx)]
+    return <Block data={block} ctx={ctx} />
   }
 }

--- a/pdl-live-react/src/view/transcript/DefContent.tsx
+++ b/pdl-live-react/src/view/transcript/DefContent.tsx
@@ -1,6 +1,6 @@
 import Code from "../Code"
+import Block from "./Block"
 import Value from "./Value"
-import show_block from "./Block"
 
 import { hasParser, hasResult, isPdlBlock } from "../../helpers"
 
@@ -26,10 +26,10 @@ export default function DefContent({ value, ctx }: Props) {
         ) : typeof value.result === "string" ? (
           <Value>{value.result}</Value>
         ) : (
-          show_block(value.result, ctx)
+          <Block data={value.result} ctx={ctx} />
         )
       ) : (
-        show_block(value, ctx)
+        <Block data={value} ctx={ctx} />
       )}
     </div>
   )

--- a/pdl-live-react/src/view/transcript/LastOf.tsx
+++ b/pdl-live-react/src/view/transcript/LastOf.tsx
@@ -1,4 +1,4 @@
-import show_block from "./Block"
+import Block from "./Block"
 
 import type Context from "../../Context"
 import { withId } from "../../Context"
@@ -10,5 +10,7 @@ type Props = {
 }
 
 export default function LastOf({ blocks, ctx }: Props) {
-  return blocks.flatMap((block, idx) => show_block(block, withId(ctx, idx)))
+  return blocks.map((block, idx) => (
+    <Block key={idx} data={block} ctx={withId(ctx, idx)} />
+  ))
 }

--- a/pdl-live-react/src/view/transcript/LoopTrace.tsx
+++ b/pdl-live-react/src/view/transcript/LoopTrace.tsx
@@ -1,26 +1,23 @@
 import { match, P } from "ts-pattern"
 
-import ArrayUI from "./Array"
-import LastOf from "./LastOf"
 import Text from "./Text"
-
-import show_blocks from "./Blocks"
+import Blocks from "./Blocks"
+import LastOf from "./LastOf"
+import ArrayUI from "./Array"
 
 import type Context from "../../Context"
 import type { Join, PdlBlock } from "../../pdl_ast"
 
-export default function show_loop_trace(
-  trace: PdlBlock[],
-  ctx: Context,
-  join_config?: Join,
-) {
+type Props = { trace: PdlBlock[]; ctx: Context; join_config?: Join }
+
+export default function LoopTrace({ trace, ctx, join_config }: Props) {
   return match(join_config)
     .with(P.nullish, () => <Text blocks={trace} ctx={ctx} />)
     .with({ as: P.union("text", P.nullish) }, (cfg) => (
       <Text blocks={trace} ctx={ctx} join_str={cfg?.with} />
     ))
     .with({ as: "array" }, () => <ArrayUI array={trace} ctx={ctx} />)
-    .with({ as: "lastOf" }, () => LastOf({ blocks: trace, ctx }))
-    .with({ with: P._ }, () => show_blocks(trace, ctx))
+    .with({ as: "lastOf" }, () => <LastOf blocks={trace} ctx={ctx} />)
+    .with({ with: P._ }, () => <Blocks blocks={trace} ctx={ctx} />)
     .exhaustive()
 }

--- a/pdl-live-react/src/view/transcript/Object.tsx
+++ b/pdl-live-react/src/view/transcript/Object.tsx
@@ -1,4 +1,4 @@
-import show_block from "./Block"
+import Block from "./Block"
 import type Context from "../../Context"
 import { type PdlBlock } from "../../pdl_ast"
 
@@ -7,14 +7,14 @@ type Props = {
   object: { [key: string]: PdlBlock }
 }
 
-export default function show_object({ object, ctx }: Props) {
+export default function ObjectUI({ object, ctx }: Props) {
   return (
     <>
       <pre>{"{"}</pre>
       {Object.keys(object).forEach((key) => (
         <>
           <pre>{key + ":"}</pre>
-          {show_block(object[key], ctx)}
+          <Block data={object[key]} ctx={ctx} />
           <pre>,</pre>
         </>
       ))}

--- a/pdl-live-react/src/view/transcript/Query.tsx
+++ b/pdl-live-react/src/view/transcript/Query.tsx
@@ -4,7 +4,7 @@ import {
   DescriptionListDescription,
 } from "@patternfly/react-core"
 
-import show_block from "./Block"
+import Block from "./Block"
 import type Context from "../../Context"
 import { type PdlBlock } from "../../pdl_ast"
 
@@ -20,7 +20,7 @@ export default function query({ q, ctx, prompt = "Query", className }: Props) {
     <DescriptionListGroup>
       <DescriptionListTerm>{prompt}</DescriptionListTerm>
       <DescriptionListDescription className={className}>
-        {show_block(q, ctx)}
+        <Block data={q} ctx={ctx} />
       </DescriptionListDescription>
     </DescriptionListGroup>
   )

--- a/pdl-live-react/src/view/transcript/Text.tsx
+++ b/pdl-live-react/src/view/transcript/Text.tsx
@@ -1,4 +1,4 @@
-import show_block from "./Block"
+import Block from "./Block"
 import { withIter } from "../../Context"
 import type Context from "../../Context"
 import { type PdlBlock } from "../../pdl_ast"
@@ -16,11 +16,11 @@ export default function Text({ className, blocks, ctx, join_str }: Props) {
       <div className={"pdl_text" + (className ? " " + className : "")}>
         {blocks.flatMap((block, idx) => [
           join_str && <div key={idx + "-join"}>{join_str}</div>,
-          <div key={idx}>{show_block(block, withIter(ctx, idx))}</div>,
+          <Block key={idx} data={block} ctx={withIter(ctx, idx)} />,
         ])}
       </div>
     )
   } else {
-    return show_block(blocks, ctx)
+    return <Block data={blocks} ctx={ctx} />
   }
 }

--- a/pdl-live-react/src/view/transcript/Transcript.tsx
+++ b/pdl-live-react/src/view/transcript/Transcript.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useContext, useMemo } from "react"
+import { useContext, useMemo } from "react"
 
 import { Stack } from "@patternfly/react-core"
 
@@ -7,7 +7,7 @@ import DrawerContext from "../../DrawerContentContext"
 import DarkModeContext from "../../DarkModeContext"
 
 import { hasResult } from "../../helpers"
-import show_block_conjoin from "./BlocksConjoin"
+import BlocksConjoin from "./BlocksConjoin"
 import FinalResult from "./FinalResult"
 
 import "./Transcript.css"
@@ -34,19 +34,7 @@ export default function Transcript({ data }: Props) {
 
   return (
     <Stack className="pdl-transcript" hasGutter>
-      {show_block_conjoin(data, ctx)
-        .flat()
-        .filter(Boolean)
-        .map((block, idx) =>
-          isValidElement(block) && "data-id" in block.props ? (
-            block
-          ) : (
-            <div key={idx} className="pdl-interstitial-text">
-              {block}
-            </div>
-          ),
-        )}
-
+      <BlocksConjoin block={data} ctx={ctx} />
       {hasResult(data) && <FinalResult block={data} ctx={ctx} />}
     </Stack>
   )

--- a/pdl-live-react/src/view/transcript/TranscriptItem.tsx
+++ b/pdl-live-react/src/view/transcript/TranscriptItem.tsx
@@ -41,7 +41,7 @@ export default function TranscriptItem(props: Props) {
   const breadcrumbs = (
     <BreadcrumbBar>
       <>
-        {[...parents, kind ?? "unknown"]
+        {[...parents, kind === "model" ? "LLM" : (kind ?? "unknown")]
           .filter(nonNullable)
           .map((parent, idx, A) => {
             const isKind = idx === A.length - 1


### PR DESCRIPTION
we had been intermixing properly nested react components with random functions that created components. this was confusing vite's HMR (hot method refresh), though didn't lead to any functional defects.