### PR TITLE
fix: code preview should always be dark in react viewer

### DIFF
--- a/pdl-live-react/src/Context.ts
+++ b/pdl-live-react/src/Context.ts
@@ -5,9 +5,6 @@ export default interface Context {
   /** Current tree parent chain as we are traversing the trace's AST, used to uniquely identify a node */
   id: string
 
-  /** Are we rendering in dark mode? */
-  darkMode: boolean
-
   /** Callback to set drawer content */
   setDrawerContent: SDC
 

--- a/pdl-live-react/src/Viewer.tsx
+++ b/pdl-live-react/src/Viewer.tsx
@@ -1,9 +1,8 @@
+import { useMemo } from "react"
 import { useLocation } from "react-router"
-import { useContext, useMemo } from "react"
 
 import Code from "./view/Code"
 import Transcript from "./view/transcript/Transcript"
-import DarkModeContext from "./DarkModeContext"
 
 import type { PdlBlock } from "./pdl_ast"
 
@@ -13,9 +12,6 @@ import "./Viewer.css"
 export default function Viewer({ value }: { value: string }) {
   // We will use this to find the current active tab (below)
   const { hash: activeTab } = useLocation()
-
-  // DarkMode state
-  const darkMode = useContext(DarkModeContext)
 
   const data = useMemo(
     () => (value ? (JSON.parse(value) as PdlBlock) : null),
@@ -29,10 +25,10 @@ export default function Viewer({ value }: { value: string }) {
   return (
     <>
       <section hidden={activeTab !== "#source"}>
-        <Code block={data} darkMode={darkMode} limitHeight={false} />
+        <Code block={data} limitHeight={false} />
       </section>
       <section hidden={activeTab !== "#raw"}>
-        <Code block={data} darkMode={darkMode} limitHeight={false} raw />
+        <Code block={data} limitHeight={false} raw />
       </section>
       <section hidden={activeTab === "#source" || activeTab === "#raw"}>
         <Transcript data={data} />

--- a/pdl-live-react/src/view/Code.tsx
+++ b/pdl-live-react/src/view/Code.tsx
@@ -8,7 +8,6 @@ import Preview, { type SupportedLanguage } from "./Preview"
 
 type Props = {
   block: PdlBlock
-  darkMode: boolean
   language?: SupportedLanguage
   showLineNumbers?: boolean
   limitHeight?: boolean
@@ -17,7 +16,6 @@ type Props = {
 
 export default function Code({
   block,
-  darkMode,
   language = "yaml",
   showLineNumbers = false,
   limitHeight = true,
@@ -25,7 +23,6 @@ export default function Code({
 }: Props) {
   return (
     <Preview
-      darkMode={darkMode}
       limitHeight={limitHeight}
       showLineNumbers={showLineNumbers ?? false}
       language={language || "yaml"}

--- a/pdl-live-react/src/view/Preview.tsx
+++ b/pdl-live-react/src/view/Preview.tsx
@@ -1,10 +1,7 @@
 import { useEffect, type PropsWithChildren } from "react"
 
 import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter"
-import {
-  oneLight as light,
-  vscDarkPlus as dark,
-} from "react-syntax-highlighter/dist/esm/styles/prism"
+import { vscDarkPlus as dark } from "react-syntax-highlighter/dist/esm/styles/prism"
 import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml"
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json"
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python"
@@ -19,7 +16,6 @@ import "./Preview.css"
 
 type Props = {
   value: string
-  darkMode?: boolean
   language?: SupportedLanguage
   showLineNumbers?: boolean
   limitHeight?: boolean
@@ -28,7 +24,6 @@ type Props = {
 export default function Preview({
   language,
   value,
-  darkMode,
   showLineNumbers,
   limitHeight,
 }: PropsWithChildren<Props>) {
@@ -42,7 +37,7 @@ export default function Preview({
   return (
     <div className="pdl-preview" data-limit-height={limitHeight}>
       <SyntaxHighlighter
-        style={darkMode ? dark : light}
+        style={dark}
         showLineNumbers={showLineNumbers}
         language={language}
       >

--- a/pdl-live-react/src/view/transcript/Block.tsx
+++ b/pdl-live-react/src/view/transcript/Block.tsx
@@ -66,24 +66,23 @@ export default function Block({ data, ctx }: Props): ReactNode {
             <Query q={data.model} ctx={ctx} prompt="Model" />
           )}
           {data.input && <Query q={data.input} ctx={ctx} />}
-          <ResultOrCode block={data} ctx={ctx} />
+          <ResultOrCode block={data} />
         </>
       ),
     }))
     .with({ kind: "code" }, (data) => ({
       C: ["pdl_code"],
-      B: <ResultOrCode block={data} ctx={ctx} term="Execution Output" />,
+      B: <ResultOrCode block={data} term="Execution Output" />,
     }))
     .with({ kind: "get" }, (data) => ({
       C: ["pdl_get"],
-      B: <ResultOrCode block={data} ctx={ctx} />,
+      B: <ResultOrCode block={data} />,
     }))
     .with({ kind: "data" }, (data) => ({
       C: ["pdl_data"],
       B: (
         <Result
           result={stringify(data.result)}
-          ctx={ctx}
           lang="yaml"
           term={data.def ?? "Struct"}
         />
@@ -119,7 +118,7 @@ export default function Block({ data, ctx }: Props): ReactNode {
       ),
       S:
         data.if_result === undefined ? (
-          <ResultOrCode block={data} ctx={ctx} />
+          <ResultOrCode block={data} />
         ) : data.if_result ? (
           <BlocksConjoin block={data?.then ?? ""} ctx={ctx} />
         ) : (
@@ -133,7 +132,7 @@ export default function Block({ data, ctx }: Props): ReactNode {
           {data.message && (
             <Query q={data.message.trim()} ctx={ctx} prompt="Question" />
           )}
-          <ResultOrCode block={data} ctx={ctx} term="Answer" />
+          <ResultOrCode block={data} term="Answer" />
         </>
       ),
     }))
@@ -142,7 +141,7 @@ export default function Block({ data, ctx }: Props): ReactNode {
       B: data.trace ? (
         <Block data={data.trace} ctx={ctx} />
       ) : (
-        <ResultOrCode block={data} ctx={ctx} />
+        <ResultOrCode block={data} />
       ),
     }))
     .with({ kind: "function" }, (data) => ({
@@ -157,7 +156,7 @@ export default function Block({ data, ctx }: Props): ReactNode {
         // const args = document.createElement('pre');
         // args.innerHTML = htmlize(stringify({call: data.call, args: data.args}));
         // body.appendChild(args);
-        <ResultOrCode block={data} ctx={ctx} />
+        <ResultOrCode block={data} />
       ),
     }))
     .with({ kind: "text" }, (data) => ({

--- a/pdl-live-react/src/view/transcript/CodeGroup.tsx
+++ b/pdl-live-react/src/view/transcript/CodeGroup.tsx
@@ -6,22 +6,20 @@ import {
 
 import Code from "../Code"
 
-import type Context from "../../Context"
 import { type SupportedLanguage } from "../Preview"
 
 type Props = {
   code: string
-  ctx: Context
   lang?: SupportedLanguage
   term?: string
 }
 
-export default function CodeGroup({ code, ctx, lang, term = "Code" }: Props) {
+export default function CodeGroup({ code, lang, term = "Code" }: Props) {
   return (
     <DescriptionListGroup>
       <DescriptionListTerm>{term}</DescriptionListTerm>
       <DescriptionListDescription>
-        <Code block={code.trim()} darkMode={ctx.darkMode} language={lang} />
+        <Code block={code.trim()} language={lang} />
       </DescriptionListDescription>
     </DescriptionListGroup>
   )

--- a/pdl-live-react/src/view/transcript/DefContent.tsx
+++ b/pdl-live-react/src/view/transcript/DefContent.tsx
@@ -19,7 +19,6 @@ export default function DefContent({ value, ctx }: Props) {
           value.parser === "jsonl") ? (
           <Code
             block={value.result}
-            darkMode={ctx.darkMode}
             limitHeight={false}
             language={value.parser === "jsonl" ? "json" : value.parser}
           />

--- a/pdl-live-react/src/view/transcript/FinalResult.tsx
+++ b/pdl-live-react/src/view/transcript/FinalResult.tsx
@@ -10,7 +10,6 @@ import { hasScalarResult } from "../../helpers"
 import "./FinalResult.css"
 
 type Props = {
-  ctx: import("../../Context").default
   block: import("../../helpers").PdlBlockWithResult
 }
 
@@ -33,7 +32,7 @@ export default function FinalResult(props: Props) {
 /**
  * @return The content UI `element` and `clipboard` content text for clipboard copying
  */
-function content({ block, ctx }: Props): {
+function content({ block }: Props): {
   clipboard: string
   element: import("react").ReactNode
 } {
@@ -58,7 +57,6 @@ function content({ block, ctx }: Props): {
           data-clipboard-content={content}
           language={typeof block.result === "object" ? "yaml" : "plaintext"}
           block={content}
-          darkMode={ctx.darkMode}
           limitHeight
         />
       ),

--- a/pdl-live-react/src/view/transcript/Function.tsx
+++ b/pdl-live-react/src/view/transcript/Function.tsx
@@ -12,8 +12,8 @@ export default function Function({ f, ctx }: Props) {
   return (
     <>
       {f.def && <Query q={f.def} prompt="Name" ctx={ctx} />}
-      <CodeGroup code={stringify(f.function)} ctx={ctx} term="Parameters" />
-      <CodeGroup code={stringify(f.return)} ctx={ctx} term="Body" />
+      <CodeGroup code={stringify(f.function)} term="Parameters" />
+      <CodeGroup code={stringify(f.return)} term="Body" />
     </>
   )
 }

--- a/pdl-live-react/src/view/transcript/Result.tsx
+++ b/pdl-live-react/src/view/transcript/Result.tsx
@@ -9,17 +9,15 @@ import {
 import Code from "../Code"
 import Value from "./Value"
 
-import type Context from "../../Context"
 import { type SupportedLanguage } from "../Preview"
 
 type Props = {
   result: number | string | unknown
-  ctx: Context
   lang?: SupportedLanguage
   term?: string
 }
 
-export default function Result({ result, ctx, lang, term = "Result" }: Props) {
+export default function Result({ result, lang, term = "Result" }: Props) {
   const isCode = lang && result
 
   return (
@@ -30,7 +28,7 @@ export default function Result({ result, ctx, lang, term = "Result" }: Props) {
           <Panel className="pdl-result-panel" isScrollable={!isCode}>
             <PanelMain>
               {isCode ? (
-                <Code block={result} darkMode={ctx.darkMode} language={lang} />
+                <Code block={result} language={lang} />
               ) : (
                 <Value>{result}</Value>
               )}

--- a/pdl-live-react/src/view/transcript/ResultOrCode.tsx
+++ b/pdl-live-react/src/view/transcript/ResultOrCode.tsx
@@ -5,26 +5,24 @@ import CodeGroup from "./CodeGroup"
 import Result from "./Result"
 import Value from "./Value"
 
-import type Context from "../../Context"
 import { type PdlBlock } from "../../pdl_ast"
 
 type Props = {
   block: PdlBlock
-  ctx: Context
   term?: string
 }
 
-export default function ResultOrCode({ block, ctx, term }: Props) {
+export default function ResultOrCode({ block, term }: Props) {
   return match(block)
     .with(P.union(P.string, P.number), (data) => <Value>{data}</Value>)
     .with({ lang: "python", code: P.string, result: P._ }, (data) => (
       <>
-        <CodeGroup code={data.code} ctx={ctx} lang={data.lang} />
-        <Result result={data.result} ctx={ctx} term={term} />
+        <CodeGroup code={data.code} lang={data.lang} />
+        <Result result={data.result} term={term} />
       </>
     ))
     .with({ result: P._ }, (data) => (
-      <Result result={data.result} ctx={ctx} term={term} />
+      <Result result={data.result} term={term} />
     ))
-    .otherwise((data) => <Code block={data} darkMode={ctx.darkMode} />)
+    .otherwise((data) => <Code block={data} />)
 }

--- a/pdl-live-react/src/view/transcript/Transcript.tsx
+++ b/pdl-live-react/src/view/transcript/Transcript.tsx
@@ -35,7 +35,7 @@ export default function Transcript({ data }: Props) {
   return (
     <Stack className="pdl-transcript" hasGutter>
       <BlocksConjoin block={data} ctx={ctx} />
-      {hasResult(data) && <FinalResult block={data} ctx={ctx} />}
+      {hasResult(data) && <FinalResult block={data} />}
     </Stack>
   )
 }

--- a/pdl-live-react/src/view/transcript/TranscriptItem.tsx
+++ b/pdl-live-react/src/view/transcript/TranscriptItem.tsx
@@ -81,11 +81,11 @@ export default function TranscriptItem(props: Props) {
         },
         {
           title: "Source",
-          body: <Code block={props.block} darkMode={ctx.darkMode} />,
+          body: <Code block={props.block} />,
         },
         {
           title: "Raw Trace",
-          body: <Code block={props.block} darkMode={ctx.darkMode} raw />,
+          body: <Code block={props.block} raw />,
         },
       ],
     })


### PR DESCRIPTION
this simplifies the viewer code, as we no longer need to pass down the darkMode state. it arguably also looks better, at least more conventional -- code is dark.