### PR TITLE
feat: enable copy button, etc. buttons for CodeEditor in react ui

### DIFF
--- a/pdl-live-react/src/view/Preview.css
+++ b/pdl-live-react/src/view/Preview.css
@@ -4,9 +4,21 @@
       max-height: 350px;
     }
   }
-  pre {
-    margin: 0 !important;
-    font-size: 1em !important;
-    font-family: "Red Hat Mono" !important;
+
+  .pf-v6-c-code-editor__tab {
+    /* Bug in patternfly? the language element shows up with 1rem font-size */
+    font-size: 0.875em;
+  }
+}
+
+/**
+ * This adds some space above the code editor component. Necessary
+   when using any of the <CodeEditor/> options that pull in the editor
+   toolbar, e.g. isCopyEnabled.
+ */
+.pf-v6-c-page__main-body,
+section {
+  & > .pdl-preview {
+    margin-top: 1em;
   }
 }

--- a/pdl-live-react/src/view/Preview.tsx
+++ b/pdl-live-react/src/view/Preview.tsx
@@ -21,7 +21,6 @@ type Props = {
 }
 
 const options: Required<CodeEditorProps>["options"] = {
-  automaticLayout: true,
   scrollBeyondLastLine: false,
   scrollbar: { alwaysConsumeMouseWheel: false },
 }
@@ -38,12 +37,14 @@ export default function Preview({
     setTimeout(() => editor.layout())
   }, [])
 
-  // other options we could enable: isCopyEnabled isDownloadEnabled isLanguageLabelVisible
   return (
     <div className="pdl-preview" data-limit-height={limitHeight}>
       <CodeEditor
         code={value}
         isDarkTheme
+        isCopyEnabled
+        isDownloadEnabled
+        isLanguageLabelVisible
         height="sizeToFit"
         options={options}
         onEditorDidMount={onEditorDidMount}


### PR DESCRIPTION
![pdl-react-viewer-v13b](https://github.com/user-attachments/assets/791f8f78-e277-4e91-9920-5890d3283c05)
