### PR TITLE
Apply defaults only after parameter processing

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1101,20 +1101,21 @@ def step_call_model(
     match concrete_block:
         case LitellmModelBlock():
             if isinstance(concrete_block.parameters, LitellmParameters):
-                # Apply PDL defaults to model invocation
-                original_params = concrete_block.parameters.model_dump()
-                revised_params = apply_defaults(
-                    str(concrete_block.model),
-                    original_params,
-                    scope.get("pdl_model_default_parameters", []),
-                )
                 concrete_block = concrete_block.model_copy(
-                    update={"parameters": revised_params}
+                    update={"parameters": concrete_block.parameters.model_dump()}
                 )
 
             _, concrete_block = process_expr_of(
                 concrete_block, "parameters", scope, loc
             )
+
+            # Apply PDL defaults to model invocation
+            if isinstance(concrete_block.parameters, dict):
+                concrete_block.parameters = apply_defaults(
+                    str(concrete_block.model),
+                    concrete_block.parameters,
+                    scope.get("pdl_model_default_parameters", []),
+                )
         case _:
             assert False
     # evaluate input

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1110,10 +1110,10 @@ def step_call_model(
             )
 
             # Apply PDL defaults to model invocation
-            if isinstance(concrete_block.parameters, dict):
+            if concrete_block.parameters is None or isinstance(concrete_block.parameters, dict):
                 concrete_block.parameters = apply_defaults(
                     str(concrete_block.model),
-                    concrete_block.parameters,
+                    concrete_block.parameters or {},
                     scope.get("pdl_model_default_parameters", []),
                 )
         case _:

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1110,7 +1110,9 @@ def step_call_model(
             )
 
             # Apply PDL defaults to model invocation
-            if concrete_block.parameters is None or isinstance(concrete_block.parameters, dict):
+            if concrete_block.parameters is None or isinstance(
+                concrete_block.parameters, dict
+            ):
                 concrete_block.parameters = apply_defaults(
                     str(concrete_block.model),
                     concrete_block.parameters or {},


### PR DESCRIPTION
Apply the default parameters later, after processing.

This is a follow-up to https://github.com/IBM/prompt-declaration-language/pull/266 based on Slack comments about the program

```PDL
defs:
    params:
      data: { temperature: 1 }
model: replicate/ibm-granite/granite-3.0-8b-instruct
parameters: ${ params }
input: Hello
```