### PR TITLE
fix: in react ui, implement mount-on-enter behavior for tabs

### DIFF
--- a/pdl-live-react/src/page/Viewer.tsx
+++ b/pdl-live-react/src/page/Viewer.tsx
@@ -1,4 +1,4 @@
-import { lazy, useMemo } from "react"
+import { lazy, useEffect, useMemo, useState } from "react"
 import { useLocation } from "react-router"
 
 const Code = lazy(() => import("../view/Code"))
@@ -10,7 +10,13 @@ import "./Viewer.css"
 /** This is the main view component */
 export default function Viewer({ value }: { value: string }) {
   // We will use this to find the current active tab (below)
-  const { hash: activeTab } = useLocation()
+  const { hash } = useLocation()
+  const activeTab = !hash || hash === "#" ? "#transcript" : hash
+
+  const [shown, setShown] = useState<Record<string, boolean>>({})
+  useEffect(() => {
+    setShown((shown) => Object.assign({}, shown, { [activeTab]: true }))
+  }, [activeTab, setShown])
 
   const data = useMemo(
     () => (value ? (JSON.parse(value) as import("../pdl_ast").PdlBlock) : null),
@@ -23,27 +29,42 @@ export default function Viewer({ value }: { value: string }) {
 
   return (
     <>
-      <section
-        className="pdl-viewer-section"
-        data-no-scroll
-        hidden={activeTab !== "#source" && activeTab !== "#raw"}
-      >
-        <Code block={data} limitHeight={false} raw={activeTab === "#raw"} />
-      </section>
-      <section
-        className="pdl-viewer-section"
-        hidden={activeTab !== "#timeline"}
-      >
-        <Timeline block={data} />
-      </section>
-      <section
-        className="pdl-viewer-section"
-        hidden={
-          !(!activeTab || activeTab === "#" || activeTab === "#transcript")
-        }
-      >
-        <Transcript data={data} />
-      </section>
+      {[
+        <section
+          className="pdl-viewer-section"
+          data-no-scroll
+          key="#source"
+          data-hash="#source"
+          hidden={activeTab !== "#source"}
+        >
+          <Code block={data} limitHeight={false} />
+        </section>,
+        <section
+          className="pdl-viewer-section"
+          data-no-scroll
+          key="#raw"
+          data-hash="#raw"
+          hidden={activeTab !== "#raw"}
+        >
+          <Code block={data} limitHeight={false} raw />
+        </section>,
+        <section
+          className="pdl-viewer-section"
+          key="#timeline"
+          data-hash="#timeline"
+          hidden={activeTab !== "#timeline"}
+        >
+          <Timeline block={data} />
+        </section>,
+        <section
+          className="pdl-viewer-section"
+          key="#transcript"
+          data-hash="#transcript"
+          hidden={activeTab !== "#transcript"}
+        >
+          <Transcript data={data} />
+        </section>,
+      ].filter((_) => shown[_.props["data-hash"]])}
     </>
   )
 }


### PR DESCRIPTION
no sense in loading all of the UI components to display the initial tab. but still avoid re-mounting tab content when switching back and forth