### PR TITLE
fix: allow more recent versions of litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "jinja2~=3.0",
   "PyYAML~=6.0",
   "jsonschema~=4.0",
-  "litellm>=1.57.3,<1.59.9",
+  "litellm>=1.57.3,!=1.59.9",
   "termcolor~=2.0",
   "ipython~=8.0",
 ]


### PR DESCRIPTION
They seem to have fixed the python 3.13 issues? Let's avoid the bad one: 1.59.9