### PR TITLE
Replace all Replicate granite 3.0 with 3.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -233,7 +233,7 @@ defs:
     parser: yaml
 text:
 - "\n${ CODE.source_code }\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input:
       - |
         Here is some info about the location of the function in the repo.
@@ -298,7 +298,7 @@ defs:
     read: ./ground_truth.txt
 text:
 - "\n${ CODE.source_code }\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   input: |
       Here is some info about the location of the function in the repo.
@@ -380,7 +380,7 @@ defs:
   TRUTH:
     read: ./ground_truth.txt
 text:
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   contribute: []
   input:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -36,7 +36,7 @@ Hello, world!
 --8<-- "./examples/tutorial/calling_llm.pdl"
 ```
 
-In this program ([file](https://github.com/IBM/prompt-declaration-language//blob/main/examples/tutorial/calling_llm.pdl)), the `text` starts with the word `"Hello\n"`, and we call a model (`replicate/ibm-granite/granite-3.0-8b-instruct`) with this as input prompt. 
+In this program ([file](https://github.com/IBM/prompt-declaration-language//blob/main/examples/tutorial/calling_llm.pdl)), the `text` starts with the word `"Hello\n"`, and we call a model (`replicate/ibm-granite/granite-3.1-8b-instruct`) with this as input prompt. 
 The model is passed a parameter `stop_sequences`.
 
 A PDL program computes 2 data structures. The first is a JSON corresponding to the result of the overall program, obtained by aggregating the results of each block. This is what is printed by default when we run the interpreter. The second is a conversational background context, which is a list of role/content pairs, where we implicitly keep track of roles and content for the purpose of communicating with models that support chat APIs. The contents in the latter correspond to the results of each block. The conversational background context is what is used to make calls to LLMs via LiteLLM.
@@ -522,7 +522,7 @@ text:
   contribute: [context]
 - repeat:
     text:
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
       role: assistant
     - read:
       def: eval
@@ -553,7 +553,7 @@ The prompt that is actually submitted to the first model call (with query `What 
 To change the template that is applied, you can specify it as a parameter of the model call:
 
 ```yaml
-model: replicate/ibm-granite/granite-3.0-8b-instruct
+model: replicate/ibm-granite/granite-3.1-8b-instruct
 parameters:
   roles:
     system:

--- a/examples/callback/repair_prompt.pdl
+++ b/examples/callback/repair_prompt.pdl
@@ -9,7 +9,7 @@ lastOf:
   Please repair the code!
 
 - def: raw_output
-  model: replicate/ibm-granite/granite-3.0-8b-instruct
+  model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     #stop_sequences: "\n\n"
     temperature: 0

--- a/examples/chatbot/chatbot.pdl
+++ b/examples/chatbot/chatbot.pdl
@@ -6,7 +6,7 @@ text:
 - repeat:
     text:
     # Send context to Granite model hosted at replicate.com
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
     # Allow the user to type 'yes', 'no', or anything else, storing
     # the input into a variable named `eval`.  The input is also implicitly
     # added to the context.

--- a/examples/cldk/cldk-assistant.pdl
+++ b/examples/cldk/cldk-assistant.pdl
@@ -36,7 +36,7 @@ text:
     - if: ${ query != 'quit'}
       then: 
         text:
-          - model: replicate/ibm-granite/granite-3.0-8b-instruct
+          - model: replicate/ibm-granite/granite-3.1-8b-instruct
             def: PDL
             input: |
                 Question: What are all the classes?
@@ -109,7 +109,7 @@ text:
                     method = PDL_SESSION.cldk_state.get_method("org.ibm.App", "Foo(string)")
                     result = method
                 - "\n\nGenerate a summary of method Foo\n\n"
-                - model: replicate/ibm-granite/granite-3.0-8b-instruct
+                - model: replicate/ibm-granite/granite-3.1-8b-instruct
                 ```
 
                 Question: Generate a different comment for method Foo(string) in class org.ibm.App?
@@ -121,7 +121,7 @@ text:
                     method = PDL_SESSION.cldk_state.get_method("org.ibm.App", "Foo(string)")
                     result = method
                 - "\n\nGenerate a different comment for method Foo(string)\n\n"
-                - model: replicate/ibm-granite/granite-3.0-8b-instruct
+                - model: replicate/ibm-granite/granite-3.1-8b-instruct
                 ```
 
                 If the query contains something about a field be sure to call a model.

--- a/examples/code/code-eval.pdl
+++ b/examples/code/code-eval.pdl
@@ -12,7 +12,7 @@ text:
 - "\n${ CODE.source_code }\n"
 # Use replicate.com to invoke a Granite model with a prompt.  Output AND
 # set the variable `EXPLANATION` to the output.
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   input: |
       Here is some info about the location of the function in the repo.

--- a/examples/code/code-json.pdl
+++ b/examples/code/code-json.pdl
@@ -6,7 +6,7 @@ defs:
   TRUTH:
     read: ./ground_truth.txt
 text:
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   contribute: []
   input:

--- a/examples/code/code.pdl
+++ b/examples/code/code.pdl
@@ -8,7 +8,7 @@ text:
 # Output the `source_code:` of the YAML to the console
 - "\n${ CODE.source_code }\n"
 # Use replicate.com to invoke a Granite model with a prompt
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
     Here is some info about the location of the function in the repo.
     repo: 

--- a/examples/demo/1-gen-data.pdl
+++ b/examples/demo/1-gen-data.pdl
@@ -6,7 +6,7 @@ defs:
     parser: yaml
     spec: { questions: [str], answers: [obj] }
 text:
-  - model: replicate/ibm-granite/granite-3.0-8b-instruct
+  - model: replicate/ibm-granite/granite-3.1-8b-instruct
     def: model_output
     spec: {name: str, age: int}
     input:

--- a/examples/demo/2-teacher.pdl
+++ b/examples/demo/2-teacher.pdl
@@ -1,6 +1,6 @@
 defs:
   teacher_sys_prompt: You are a very knowledgeable AI Assistant that will faithfully assist the user with their task.
-  teacher_model: replicate/ibm-granite/granite-3.0-8b-instruct
+  teacher_model: replicate/ibm-granite/granite-3.1-8b-instruct
   teacher_template:
     function:
       sys_prompt: str

--- a/examples/demo/3-weather.pdl
+++ b/examples/demo/3-weather.pdl
@@ -2,7 +2,7 @@ description: Using a weather API and LLM to make a small weather app
 text:
 - def: QUERY
   text: "What is the weather in Madrid?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
       Extract the location from the question.
       Question: What is the weather in London?
@@ -25,7 +25,7 @@ text:
   def: WEATHER
   parser: json
   contribute: []
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
       Explain the weather from the following JSON:
       ${ WEATHER }

--- a/examples/demo/4-translator.pdl
+++ b/examples/demo/4-translator.pdl
@@ -1,7 +1,7 @@
 description: PDL program
 text:
 - "What is APR?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
 - repeat:
     text:
     - read:
@@ -11,5 +11,5 @@ text:
       then:
         text:
         - "\n\nTranslate the above to ${ language }\n"
-        - model: replicate/ibm-granite/granite-3.0-8b-instruct
+        - model: replicate/ibm-granite/granite-3.1-8b-instruct
   until: ${ language == 'stop' }

--- a/examples/fibonacci/fib.pdl
+++ b/examples/fibonacci/fib.pdl
@@ -6,7 +6,7 @@ text:
 # Use IBM Granite to author a program that computes the Nth Fibonacci number,
 # storing the generated program into the variable `CODE`.
 - def: CODE
-  model: replicate/ibm-granite/granite-3.0-8b-instruct
+  model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: "Write a Python function to compute the Fibonacci sequence. Do not include a doc string.\n\n"
   parameters:
     # Request no randomness when generating code
@@ -42,5 +42,5 @@ text:
 
 # Invoke the LLM again to explain the PDL context
 - "\n\nExplain what the above code does and what the result means\n\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   

--- a/examples/granite/multi_round_chat.pdl
+++ b/examples/granite/multi_round_chat.pdl
@@ -18,7 +18,7 @@ text:
 
       ${ prompt }
     # Use replicate.com to run the Granite model on the context, outputting the result
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         # Use no LLM model creativity (0 is the default)
         temperature: 0

--- a/examples/granite/single_round_chat.pdl
+++ b/examples/granite/single_round_chat.pdl
@@ -2,7 +2,7 @@ description: Granite Single-Round Chat
 text:
 # (Note that 'PROMPT' is undefined will happen if you don't invoke pdl with `-f prompt.json`)
 - "${ PROMPT }\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     # Use no LLM model creativity (0 is the default)
     temperature: 0

--- a/examples/hello/hello-code-pdl.pdl
+++ b/examples/hello/hello-code-pdl.pdl
@@ -4,5 +4,5 @@ code: |
   description: Hello world
   text:
   - "Hello\n"
-  - model: replicate/ibm-granite/granite-3.0-8b-instruct
+  - model: replicate/ibm-granite/granite-3.1-8b-instruct
   

--- a/examples/hello/hello-def-use.pdl
+++ b/examples/hello/hello-def-use.pdl
@@ -2,7 +2,7 @@ description: Hello world with variable use
 text:
 - "Hello\n"
 # Define GEN to be the result of a Granite LLM using replicate.com
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     # "greedy" sampling tells the LLM to use the most likely token at each step
     decoding_method: greedy

--- a/examples/hello/hello-model-chaining.pdl
+++ b/examples/hello/hello-model-chaining.pdl
@@ -1,7 +1,7 @@
 description: Hello world showing model chaining
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     # "greedy" sampling tells the LLM to use the most likely token at each step
     decoding_method: greedy
@@ -9,7 +9,7 @@ text:
     stop_sequences: '!'
   def: GEN
 - "\nDid you say ${ GEN }?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     decoding_method: greedy
     stop_sequences: '.'

--- a/examples/hello/hello-model-input.pdl
+++ b/examples/hello/hello-model-input.pdl
@@ -1,6 +1,6 @@
 description: Hello world with model input
 text:
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: "Hello,"
   parameters:
     # Tell the LLM to stop after generating an exclamation point.

--- a/examples/hello/hello-parser-json.pdl
+++ b/examples/hello/hello-parser-json.pdl
@@ -5,7 +5,7 @@ defs:
     parser: yaml
     spec: { questions: [str], answers: [obj] }
 text:
-  - model: replicate/ibm-granite/granite-3.0-8b-instruct
+  - model: replicate/ibm-granite/granite-3.1-8b-instruct
     def: model_output
     spec: {name: str, age: int}
     input:

--- a/examples/hello/hello-parser-regex.pdl
+++ b/examples/hello/hello-parser-regex.pdl
@@ -1,6 +1,6 @@
 description: Hello world with parser using regex
 text:
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: "Hello,"
   parameters:
     # Tell the LLM to stop after generating an exclamation point.

--- a/examples/hello/hello-roles-array.pdl
+++ b/examples/hello/hello-roles-array.pdl
@@ -7,6 +7,6 @@ text:
   - role: user
     content: Write a Python function that implement merge sort.
   contribute: []
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: ${ prompt }
 

--- a/examples/hello/hello-type.pdl
+++ b/examples/hello/hello-type.pdl
@@ -11,7 +11,7 @@ text:
   return:
     lastOf:
     - "\nTranslate the sentence '${ sentence }' to ${ language }.\n"
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "\n"
 - call: ${ translate }

--- a/examples/hello/hello.pdl
+++ b/examples/hello/hello.pdl
@@ -1,4 +1,4 @@
 description: Hello world
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct

--- a/examples/notebooks/demo.ipynb
+++ b/examples/notebooks/demo.ipynb
@@ -162,7 +162,7 @@
     "%%pdl --reset-context\n",
     "text: \n",
     "- \"What is the meaning of life?\\n\"\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\""
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\""
    ]
   },
   {
@@ -213,9 +213,9 @@
     "%%pdl\n",
     "text:\n",
     "- \"\\nSay it like a poem\\n\"\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\"\n",
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\"\n",
     "- \"\\n\\nTranslate it to French\\n\"\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\""
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\""
    ]
   },
   {
@@ -305,7 +305,7 @@
     "    read: ./ground_truth.txt\n",
     "text:\n",
     "- \"\\n${ code.source_code }\\n\"\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\"\n",
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\"\n",
     "  def: explanation\n",
     "  input: |\n",
     "      Here is some info about the location of the function in the repo.\n",
@@ -393,12 +393,12 @@
     "- repeat:\n",
     "    text:\n",
     "    - def: thought\n",
-    "      model: replicate/ibm-granite/granite-3.0-8b-instruct\n",
+    "      model: replicate/ibm-granite/granite-3.1-8b-instruct\n",
     "      parameters:\n",
     "        stop_sequences: \"Act:\"\n",
     "        temperature: 0\n",
     "    - def: rawAction\n",
-    "      model: replicate/ibm-granite/granite-3.0-8b-instruct\n",
+    "      model: replicate/ibm-granite/granite-3.1-8b-instruct\n",
     "      parameters:\n",
     "        stop_sequences: \"\\n\"\n",
     "        temperature: 0\n",

--- a/examples/notebooks/notebook.ipynb
+++ b/examples/notebooks/notebook.ipynb
@@ -30,7 +30,7 @@
     "description: Model call\n",
     "text: \n",
     "- \"Hello\\n\"\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\"\n",
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\"\n",
     "  parameters:\n",
     "    stop_sequences: \"!\"\n",
     " "
@@ -89,7 +89,7 @@
     "    read: ./ground_truth.txt\n",
     "text:\n",
     "- \"\\n${ CODE.source_code }\\n\"\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\"\n",
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\"\n",
     "  def: EXPLANATION\n",
     "  input: |\n",
     "      Here is some info about the location of the function in the repo.\n",

--- a/examples/notebooks/notebook_debug.ipynb
+++ b/examples/notebooks/notebook_debug.ipynb
@@ -164,7 +164,7 @@
     "description: Model call\n",
     "text: \n",
     "- Hello,\n",
-    "- model: \"replicate/ibm-granite/granite-3.0-8b-instruct\"\n",
+    "- model: \"replicate/ibm-granite/granite-3.1-8b-instruct\"\n",
     "  parameters:\n",
     "    stop_sequences: \"!\""
    ]

--- a/examples/rag/rag.pdl
+++ b/examples/rag/rag.pdl
@@ -42,4 +42,4 @@ text:
 
     Q: ${ TEST_PROMPT }
     A: 
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct

--- a/examples/react/demo.pdl
+++ b/examples/react/demo.pdl
@@ -52,12 +52,12 @@ text:
 - repeat:
     text:
     - def: thought
-      model: replicate/ibm-granite/granite-3.0-8b-instruct
+      model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "Act:"
     - "Act:\n"
     - def: action
-      model: replicate/ibm-granite/granite-3.0-8b-instruct
+      model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "\n"
       parser: json

--- a/examples/react/react_call.pdl
+++ b/examples/react/react_call.pdl
@@ -4,6 +4,6 @@ text:
   - call: ${ react }
     args:
       question: How many years ago was the discoverer of the Hudson River born? Keep in mind we are in 2024.
-      model: replicate/ibm-granite/granite-3.0-8b-instruct
+      model: replicate/ibm-granite/granite-3.1-8b-instruct
 
 

--- a/examples/sdk/hello.pdl
+++ b/examples/sdk/hello.pdl
@@ -1,5 +1,5 @@
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: '!'

--- a/examples/sdk/hello_dict.py
+++ b/examples/sdk/hello_dict.py
@@ -4,7 +4,7 @@ hello = {
     "text": [
         "Hello\n",
         {
-            "model": "replicate/ibm-granite/granite-3.0-8b-instruct",
+            "model": "replicate/ibm-granite/granite-3.1-8b-instruct",
             "parameters": {"stop_sequences": "!"},
         },
     ]

--- a/examples/sdk/hello_prog.py
+++ b/examples/sdk/hello_prog.py
@@ -6,7 +6,7 @@ hello = Program(
         text=[
             "Hello\n",
             LitellmModelBlock(
-                model="replicate/ibm-granite/granite-3.0-8b-instruct",
+                model="replicate/ibm-granite/granite-3.1-8b-instruct",
                 parameters=LitellmParameters(stop_sequences="!"),  # pyright: ignore
             ),
         ]

--- a/examples/sdk/hello_str.py
+++ b/examples/sdk/hello_str.py
@@ -3,7 +3,7 @@ from pdl.pdl import exec_str
 HELLO = """
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: '!'
 """

--- a/examples/talk/1-hello.pdl
+++ b/examples/talk/1-hello.pdl
@@ -1,7 +1,7 @@
 description: Model call
 text: 
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: "!"
     include_stop_sequence: true

--- a/examples/talk/10-sdg.pdl
+++ b/examples/talk/10-sdg.pdl
@@ -1,6 +1,6 @@
 defs:
   teacher_sys_prompt: You are a very knowledgeable AI Assistant that will faithfully assist the user with their task.
-  teacher_model: replicate/ibm-granite/granite-3.0-8b-instruct
+  teacher_model: replicate/ibm-granite/granite-3.1-8b-instruct
   teacher_template:
     function:
       sys_prompt: str

--- a/examples/talk/2-model-chaining.pdl
+++ b/examples/talk/2-model-chaining.pdl
@@ -1,11 +1,11 @@
 description: Model chaining
 text: 
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: "!"
 - "\nDid you just say Hello?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: "!"
     

--- a/examples/talk/3-def-use.pdl
+++ b/examples/talk/3-def-use.pdl
@@ -1,12 +1,12 @@
 description: Variable def and use, model input
 text: 
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: name
   parameters:
     stop_sequences: "!"
 - "\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: "Translate the word ${ name | trim } to French\n"
   parameters:
     stop_sequences: "\n"

--- a/examples/talk/4-function.pdl
+++ b/examples/talk/4-function.pdl
@@ -7,7 +7,7 @@ text:
   return:
     lastOf:
     - "\nTranslate the sentence '${ sentence }' to ${ language }.\n"
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "\n"
         temperature: 0

--- a/examples/talk/5-code-eval.pdl
+++ b/examples/talk/5-code-eval.pdl
@@ -7,7 +7,7 @@ defs:
     read: ./ground_truth.txt
 text:
 - "\n${ CODE.source_code }\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   input: |
       Here is some info about the location of the function in the repo.

--- a/examples/talk/6-code-json.pdl
+++ b/examples/talk/6-code-json.pdl
@@ -6,7 +6,7 @@ defs:
   TRUTH:
     read: ./ground_truth.txt
 text:
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   contribute: []
   input:

--- a/examples/talk/7-chatbot-roles.pdl
+++ b/examples/talk/7-chatbot-roles.pdl
@@ -10,7 +10,7 @@ text:
       message: ">>> "
       def: query
       contribute: [context]
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
     - "\n\n"
   until: ${ query == 'quit'}
   join:

--- a/examples/talk/8-tools.pdl
+++ b/examples/talk/8-tools.pdl
@@ -23,7 +23,7 @@ text:
   contribute: [context]
 - "Out of 1400 participants, 400 passed the test. What percentage is that?\n"
 - def: actions
-  model: replicate/ibm-granite/granite-3.0-8b-instruct
+  model: replicate/ibm-granite/granite-3.1-8b-instruct
   parser: json
   spec: [{ name: str, arguments: { expr: str }}]  
 - "\n"

--- a/examples/talk/9-react.pdl
+++ b/examples/talk/9-react.pdl
@@ -33,6 +33,7 @@ text:
   text: ${ tools }
   contribute: [context]
 - text:
+    # This is just a single-shot demonstration prompt, not work we expect done.
     |
     What profession does Nicholas Ray and Elia Kazan have in common?
     Tho: I need to search Nicholas Ray and Elia Kazan, find their professions, then find the profession they have in common.
@@ -52,12 +53,12 @@ text:
 - repeat:
     text:
     - def: thought
-      model: replicate/ibm-granite/granite-3.0-8b-instruct
+      model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "Act:"
     - "Act:\n"
     - def: action
-      model: replicate/ibm-granite/granite-3.0-8b-instruct
+      model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "\n"
       parser: json

--- a/examples/teacher/teacher.pdl
+++ b/examples/teacher/teacher.pdl
@@ -1,6 +1,6 @@
 defs:
   teacher_sys_prompt: You are a very knowledgeable AI Assistant that will faithfully assist the user with their task.
-  teacher_model: replicate/ibm-granite/granite-3.0-8b-instruct
+  teacher_model: replicate/ibm-granite/granite-3.1-8b-instruct
   teacher_template:
     function:
       sys_prompt: str

--- a/examples/tools/calc.pdl
+++ b/examples/tools/calc.pdl
@@ -23,7 +23,7 @@ text:
   contribute: [context]
 - "Out of 1400 participants, 400 passed the test. What percentage is that?\n"
 - def: actions
-  model: replicate/ibm-granite/granite-3.0-8b-instruct
+  model: replicate/ibm-granite/granite-3.1-8b-instruct
   parser: json
   spec: [{ name: str, arguments: { expr: str }}]  
 - "\n"

--- a/examples/tutorial/calling_apis.pdl
+++ b/examples/tutorial/calling_apis.pdl
@@ -2,7 +2,7 @@ description: Using a weather API and LLM to make a small weather app
 text:
 - def: QUERY
   text: "What is the weather in Madrid?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
       Extract the location from the question.
       Question: What is the weather in London?
@@ -25,7 +25,7 @@ text:
   def: WEATHER
   parser: json
   contribute: []
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
       Explain the weather from the following JSON:
       ${ WEATHER }

--- a/examples/tutorial/calling_llm.pdl
+++ b/examples/tutorial/calling_llm.pdl
@@ -1,6 +1,6 @@
 description: Hello world calling a model
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: '!'

--- a/examples/tutorial/calling_llm_with_input.pdl
+++ b/examples/tutorial/calling_llm_with_input.pdl
@@ -1,6 +1,6 @@
 description: Hello world calling a model
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: 
     Translate the word 'Hello' to French

--- a/examples/tutorial/calling_llm_with_input_messages.pdl
+++ b/examples/tutorial/calling_llm_with_input_messages.pdl
@@ -1,7 +1,7 @@
 description: Hello world calling a model
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input:
     array:
     - role: system

--- a/examples/tutorial/conditionals_loops.pdl
+++ b/examples/tutorial/conditionals_loops.pdl
@@ -5,7 +5,7 @@ text:
   contribute: [context]
 - repeat:
     text:
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
     - read:
       def: eval
       message: "\nIs this a good answer[yes/no]?\n"

--- a/examples/tutorial/data_block.pdl
+++ b/examples/tutorial/data_block.pdl
@@ -6,7 +6,7 @@ defs:
   TRUTH:
     read: ./ground_truth.txt
 lastOf:
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: EXPLANATION
   input:
      |

--- a/examples/tutorial/function_definition.pdl
+++ b/examples/tutorial/function_definition.pdl
@@ -7,7 +7,7 @@ text:
   return:
     lastOf:
     - "\nTranslate the sentence '${ sentence }' to ${ language }.\n"
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         stop_sequences: "\n"
         temperature: 0

--- a/examples/tutorial/gen-data.pdl
+++ b/examples/tutorial/gen-data.pdl
@@ -5,7 +5,7 @@ defs:
     parser: yaml
     spec: { questions: [str], answers: [obj] }
 text:
-  - model: replicate/ibm-granite/granite-3.0-8b-instruct
+  - model: replicate/ibm-granite/granite-3.1-8b-instruct
     def: model_output
     spec: {name: str, age: int}
     input:

--- a/examples/tutorial/grouping_definitions.pdl
+++ b/examples/tutorial/grouping_definitions.pdl
@@ -7,7 +7,7 @@ defs:
     return:
       lastOf:
       - "\nTranslate the sentence '${ sentence }' to ${ language }.\n"
-      - model: replicate/ibm-granite/granite-3.0-8b-instruct
+      - model: replicate/ibm-granite/granite-3.1-8b-instruct
         parameters:
           stop_sequences: "\n"
 text:

--- a/examples/tutorial/include.pdl
+++ b/examples/tutorial/include.pdl
@@ -13,7 +13,7 @@ text:
     - |
     
       ${ prompt }
-    - model: replicate/ibm-granite/granite-3.0-8b-instruct
+    - model: replicate/ibm-granite/granite-3.1-8b-instruct
       parameters:
         decoding_method: sample
         max_new_tokens: 512

--- a/examples/tutorial/model_chaining.pdl
+++ b/examples/tutorial/model_chaining.pdl
@@ -1,10 +1,10 @@
 description: Model chaining
 text: 
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: "!"
 - "\nDid you just say Hello?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   parameters:
     stop_sequences: "!"

--- a/examples/tutorial/muting_block_output.pdl
+++ b/examples/tutorial/muting_block_output.pdl
@@ -8,7 +8,7 @@ defs:
       text:
       - text: "\nTranslate the sentence '${ sentence }' to ${ language }.\n"
         contribute: [context]
-      - model: replicate/ibm-granite/granite-3.0-8b-instruct
+      - model: replicate/ibm-granite/granite-3.1-8b-instruct
         parameters:
           stop_sequences: "\n"
 text:

--- a/examples/tutorial/variable_def_use.pdl
+++ b/examples/tutorial/variable_def_use.pdl
@@ -1,7 +1,7 @@
 description: Hello world with variable def and use
 text:
 - "Hello\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   def: GEN
   parameters:
     stop_sequences: '!'

--- a/examples/weather/weather.pdl
+++ b/examples/weather/weather.pdl
@@ -2,7 +2,7 @@ description: Using a weather API and LLM to make a small weather app
 text:
 - def: QUERY
   text: "What is the weather in Madrid?\n"
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
       Extract the location from the question.
       Question: What is the weather in London?
@@ -25,7 +25,7 @@ text:
   def: WEATHER
   parser: json
   contribute: []
-- model: replicate/ibm-granite/granite-3.0-8b-instruct
+- model: replicate/ibm-granite/granite-3.1-8b-instruct
   input: |
       Explain the weather from the following JSON:
       ${ WEATHER }

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -694,7 +694,7 @@ def get_default_model_parameters() -> list[dict[str, Any]]:
         },
         # Note that we match both granite-3.0 and 3.1 rather than using a granite-3.* wildcard
         {
-            "replicate*granite-3.1*": {
+            "*granite-3.1*": {
                 "temperature": 0,
                 "roles": {
                     "system": {

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -663,8 +663,38 @@ def get_default_model_parameters() -> list[dict[str, Any]]:
                 "repetition_penalty": REPETITION_PENALTY,
             },
         },
+        # Note that Replicate may no longer support granite 3.0
         {
             "replicate*granite-3.0*": {
+                "temperature": 0,
+                "roles": {
+                    "system": {
+                        "pre_message": "<|start_of_role|>system<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "user": {
+                        "pre_message": "<|start_of_role|>user<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "assistant": {
+                        "pre_message": "<|start_of_role|>assistant<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "available_tools": {
+                        "pre_message": "<|start_of_role|>available_tools<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                    "tool_response": {
+                        "pre_message": "<|start_of_role|>tool_response<|end_of_role|>",
+                        "post_message": "<|end_of_text|>",
+                    },
+                },
+                "final_prompt_value": "<|start_of_role|>assistant<|end_of_role|>",
+            }
+        },
+        # Note that we match both granite-3.0 and 3.1 rather than using a granite-3.* wildcard
+        {
+            "replicate*granite-3.1*": {
                 "temperature": 0,
                 "roles": {
                     "system": {

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -72,7 +72,7 @@ def test_default_model_params():
 
     # Granite-3.0 defaults for this model
     params = apply_defaults(
-        "replicate/ibm-granite/granite-3.0-8b-instruct", {}, model_defaults
+        "replicate/ibm-granite/granite-3.1-8b-instruct", {}, model_defaults
     )
     assert {
         "temperature": 0,


### PR DESCRIPTION
This fixes problems with Replicate returning `Error during 'replicate/ibm-granite/granite-3.0-8b-instruct' model call: litellm.UnprocessableEntityError: ReplicateException - {"title":"Version disabled","detail":"This deployment is currently disabled:\n- This deployment has been disabled in its settings.","status":422}`

This fixes Granite 3.1 so that it generates prompts as expected.

This PR introduces some new problems that will need to be fixed here or in a follow-up.

- With this fix applied, the 9-react.pdl example gets the correct answer, although it fails with a new error after that.
- With this fix applied, _examples/weather/weather.pdl_ fails with a JSON decoding error.

I started investigating the new errors.  Probably they reflect places the example prompts don't produce the expected output.  Unfortunately, while testing, I started getting `402 Payment Required` from Replicate even though I had an API key.