### PR TITLE
fix: in react ui, show code blocks in purple

### DIFF
--- a/pdl-live-react/src/view/masonry/Masonry.css
+++ b/pdl-live-react/src/view/masonry/Masonry.css
@@ -45,7 +45,7 @@
     background: var(--pf-t--global--color--nonstatus--orange--default);
   }
   &[data-kind="code"] {
-    background: var(--pf-t--global--color--nonstatus--blue--default);
+    background: var(--pf-t--global--color--nonstatus--purple--default);
   }
 }
 

--- a/pdl-live-react/src/view/memory/Node.tsx
+++ b/pdl-live-react/src/view/memory/Node.tsx
@@ -19,7 +19,7 @@ const CustomNode: FunctionComponent<CustomNodeProps> = (
   const badgeColor = /Read/.test(label)
     ? "var(--pf-t--global--color--nonstatus--orange--default)"
     : /Code/.test(label)
-      ? "var(--pf-t--global--color--nonstatus--blue--default)"
+      ? "var(--pf-t--global--color--nonstatus--purple--default)"
       : /LLM/.test(label)
         ? "var(--pf-t--global--color--nonstatus--teal--default)"
         : "var(--pf-t--color--white)"

--- a/pdl-live-react/src/view/timeline/Timeline.css
+++ b/pdl-live-react/src/view/timeline/Timeline.css
@@ -84,7 +84,7 @@
     background-color: var(--pf-t--global--icon--color--disabled);
   }
   &[data-kind="code"] {
-    background-color: var(--pf-t--global--color--nonstatus--blue--default);
+    background-color: var(--pf-t--global--color--nonstatus--purple--default);
   }
   &[data-kind="read"] {
     background-color: var(--pf-t--global--color--nonstatus--orange--default);


### PR DESCRIPTION
The previous blue overlapped colors with the blue "variable" breadcrumbs.