### PR TITLE
fix: in react ui, topology labels should be see-through

### DIFF
--- a/pdl-live-react/src/view/memory/Topology.css
+++ b/pdl-live-react/src/view/memory/Topology.css
@@ -1,0 +1,3 @@
+.pf-topology__node__label__background {
+  fill-opacity: 0.75;
+}

--- a/pdl-live-react/src/view/memory/Topology.tsx
+++ b/pdl-live-react/src/view/memory/Topology.tsx
@@ -17,6 +17,8 @@ import {
 import layoutFactory from "./layout"
 import componentFactory from "./components"
 
+import "./Topology.css"
+
 const NODE_SHAPE = NodeShape.ellipse
 const NODE_DIAMETER = 10
 


### PR DESCRIPTION
So that edges can be seen underneath the labels