### PR TITLE
feat: in react UI, add Run button to support re-running program

### DIFF
--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-window-state",
  "tempdir",
+ "tempfile",
  "urlencoding",
 ]
 

--- a/pdl-live-react/src-tauri/Cargo.toml
+++ b/pdl-live-react/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempdir = "0.3.7"
 urlencoding = "2.1.3"
+tempfile = "3.16.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-cli = "2"

--- a/pdl-live-react/src-tauri/src/cli/run.rs
+++ b/pdl-live-react/src-tauri/src/cli/run.rs
@@ -1,15 +1,30 @@
+use std::fs::read;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use tempfile::NamedTempFile;
 
 #[cfg(desktop)]
 pub fn run_pdl_program(
     source_file_path: String,
     interpreter_path: PathBuf,
-) -> Result<(), tauri::Error> {
+    trace: bool,
+) -> Result<Option<Vec<u8>>, tauri::Error> {
     println!("Running {:?}", source_file_path);
     //let interp = interpreter_path.display().to_string()
     let activate = interpreter_path.join("bin/activate").display().to_string();
+
+    let (trace_file, trace_arg) = if trace {
+        let f = NamedTempFile::new()?;
+        let arg = match f.path().to_str() {
+            Some(path) => "--trace ".to_owned() + path,
+            None => "".to_owned(),
+        };
+        (Some(f), arg)
+    } else {
+        (None, "".to_owned())
+    };
+
     let mut child = Command::new("sh")
         .args([
             "-c",
@@ -17,6 +32,7 @@ pub fn run_pdl_program(
                 "source",
                 activate.as_str(),
                 "; pdl",
+                trace_arg.as_str(),
                 source_file_path.as_str(),
             ]
             .join(" "),
@@ -33,5 +49,14 @@ pub fn run_pdl_program(
         println!("{}", line.unwrap());
     }
 
-    Ok(())
+    if trace {
+        match trace_file {
+            Some(path) => {
+                return Ok(Some(read(path).unwrap()));
+            }
+            None => (),
+        }
+    }
+
+    Ok(None)
 }

--- a/pdl-live-react/src-tauri/src/cli/setup.rs
+++ b/pdl-live-react/src-tauri/src/cli/setup.rs
@@ -28,7 +28,11 @@ pub fn cli(app: &mut tauri::App) -> Result<(), tauri::Error> {
                                 .path()
                                 .resolve("interpreter/", BaseDirectory::Resource)?;
 
-                            run::run_pdl_program(source_file_path.clone(), interpreter_path)?;
+                            run::run_pdl_program(
+                                source_file_path.clone(),
+                                interpreter_path,
+                                false,
+                            )?;
                             exit(0)
                         }
                     }

--- a/pdl-live-react/src-tauri/src/commands/mod.rs
+++ b/pdl-live-react/src-tauri/src/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod read_trace;
+pub mod replay;

--- a/pdl-live-react/src-tauri/src/commands/replay.rs
+++ b/pdl-live-react/src-tauri/src/commands/replay.rs
@@ -1,0 +1,36 @@
+use std::io::Write;
+use tempfile::NamedTempFile;
+//use tauri::ipc::Response;
+
+use tauri::path::BaseDirectory;
+use tauri::Manager;
+
+use crate::cli::run::run_pdl_program;
+
+// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+#[tauri::command]
+pub async fn replay(app_handle: tauri::AppHandle, trace: String) -> Result<String, String> {
+    let mut file = NamedTempFile::new().map_err(|e| e.to_string())?;
+    file.write_all(trace.as_bytes())
+        .map_err(|e| e.to_string())?;
+
+    let interpreter_path = app_handle
+        .path()
+        .resolve("interpreter/", BaseDirectory::Resource)
+        .map_err(|e| e.to_string())?;
+
+    match file.path().to_str() {
+        Some(path) => {
+            let data = run_pdl_program(path.to_string(), interpreter_path, true)
+                .map_err(|e| e.to_string())?;
+            match data {
+                Some(bytes) => {
+                    let string = String::from_utf8(bytes).expect("Our bytes should be valid utf8");
+                    Ok(string)
+                }
+                None => Err("Could not replay the trace".to_string()),
+            }
+        }
+        None => Err("Could not stage to file".to_string()),
+    }
+}

--- a/pdl-live-react/src-tauri/src/lib.rs
+++ b/pdl-live-react/src-tauri/src/lib.rs
@@ -19,7 +19,10 @@ pub fn run() {
         })
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![commands::read_trace::read_trace])
+        .invoke_handler(tauri::generate_handler![
+            commands::read_trace::read_trace,
+            commands::replay::replay
+        ])
         .run(tauri::generate_context!())
         .expect("error while running PDL");
 }

--- a/pdl-live-react/src/page/Demo.tsx
+++ b/pdl-live-react/src/page/Demo.tsx
@@ -6,5 +6,5 @@ type Props = {
 }
 
 export default function Demo({ name, value }: Props) {
-  return <Page breadcrumb1="Demos" breadcrumb2={name} value={value} />
+  return <Page breadcrumb1="Demos" breadcrumb2={name} initialValue={value} />
 }

--- a/pdl-live-react/src/page/Local.tsx
+++ b/pdl-live-react/src/page/Local.tsx
@@ -36,7 +36,7 @@ export default function Local() {
     <Page
       breadcrumb1="Local"
       breadcrumb2={traceFile?.replace(/\.json$/, "")}
-      value={value}
+      initialValue={value}
     />
   )
 }

--- a/pdl-live-react/src/page/MyTrace.tsx
+++ b/pdl-live-react/src/page/MyTrace.tsx
@@ -6,5 +6,7 @@ type Props = {
 }
 
 export default function MyTrace({ name, value }: Props) {
-  return <Page breadcrumb1="My Traces" breadcrumb2={name} value={value} />
+  return (
+    <Page breadcrumb1="My Traces" breadcrumb2={name} initialValue={value} />
+  )
 }

--- a/pdl-live-react/src/page/Page.tsx
+++ b/pdl-live-react/src/page/Page.tsx
@@ -24,25 +24,22 @@ type Props = import("react").PropsWithChildren<
     /** Should the page content use default padding? [default: true] */
     padding?: boolean
 
-    /** The trace content */
-    value?: string
+    /** The initial trace content */
+    initialValue?: string
   }
 >
 
 export default function PDLPage(props: Props) {
+  const { padding = true, initialValue, children } = props
+
   const [darkMode, setDarkMode] = useState(getDarkModeUserSetting())
   useEffect(() => setDarkModeForSession(getDarkModeUserSetting()), [])
 
-  const { padding = true, value, children } = props
+  const [value, setValue] = useState(initialValue)
 
   /** Manage the drawer that slides in from the right */
   const [searchParams] = useSearchParams()
   const showingDetail = searchParams.has("detail") && !!value
-
-  if (value) {
-    // Fail fast if `value` is bogus
-    JSON.parse(value)
-  }
 
   return (
     <Page
@@ -67,7 +64,8 @@ export default function PDLPage(props: Props) {
       }
     >
       {!children ? (
-        value && value.length > 0 && <MasonryCombo value={value} />
+        value &&
+        value.length > 0 && <MasonryCombo value={value} setValue={setValue} />
       ) : (
         <PageSection
           isFilled

--- a/pdl-live-react/src/view/masonry/MasonryCombo.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryCombo.tsx
@@ -12,6 +12,7 @@ import "./Masonry.css"
 
 type Props = {
   value: string
+  setValue(value: string): void
 }
 
 const asLocalStorageKey = "pdl-viewer.masonry.as"
@@ -31,7 +32,7 @@ function setSMLUserSetting(sml: SML) {
 }
 
 /** Combines <Masonry/>, <Timeline/>, ... */
-export default function MasonryCombo({ value }: Props) {
+export default function MasonryCombo({ value, setValue }: Props) {
   const block = useMemo(
     () =>
       value ? (JSON.parse(value) as import("../../pdl_ast").PdlBlock) : null,
@@ -56,7 +57,14 @@ export default function MasonryCombo({ value }: Props) {
   return (
     <>
       <PageSection type="subnav">
-        <Toolbar as={as} setAs={setAs} sml={sml} setSML={setSML} />
+        <Toolbar
+          as={as}
+          setAs={setAs}
+          sml={sml}
+          setSML={setSML}
+          block={block}
+          setValue={setValue}
+        />
       </PageSection>
       <PageSection
         isFilled

--- a/pdl-live-react/src/view/masonry/Toolbar.tsx
+++ b/pdl-live-react/src/view/masonry/Toolbar.tsx
@@ -1,12 +1,8 @@
-import {
-  Toolbar,
-  ToolbarGroup,
-  ToolbarContent,
-  ToolbarItem,
-} from "@patternfly/react-core"
+import { Toolbar, ToolbarGroup, ToolbarContent } from "@patternfly/react-core"
 
 import ToolbarAsToggle from "./ToolbarAsToggle"
 import ToolbarSMLToggle from "./ToolbarSMLToggle"
+import ToolbarReplayButton from "./ToolbarReplayButton"
 import ToolbarShowSourceButton from "./ToolbarShowSourceButton"
 
 const alignEnd = { default: "alignEnd" as const }
@@ -15,6 +11,9 @@ export type As = "grid" | "list"
 export type SML = "s" | "m" | "l"
 
 export type Props = {
+  block: import("../../pdl_ast").PdlBlock
+  setValue(value: string): void
+
   as: As
   setAs(as: As): void
 
@@ -22,20 +21,24 @@ export type Props = {
   setSML(sml: SML): void
 }
 
-export default function MasonryToolbar({ as, setAs, sml, setSML }: Props) {
+export default function MasonryToolbar({
+  as,
+  setAs,
+  sml,
+  setSML,
+  block,
+  setValue,
+}: Props) {
   return (
     <Toolbar className="pdl-masonry-toolbar">
       <ToolbarContent>
+        <ToolbarGroup variant="action-group-plain">
+          <ToolbarReplayButton block={block} setValue={setValue} />
+          <ToolbarShowSourceButton />
+        </ToolbarGroup>
         <ToolbarGroup align={alignEnd} variant="action-group">
-          <ToolbarItem>
-            <ToolbarShowSourceButton />
-          </ToolbarItem>
-          <ToolbarItem>
-            <ToolbarSMLToggle sml={sml} setSML={setSML} />
-          </ToolbarItem>
-          <ToolbarItem>
-            <ToolbarAsToggle as={as} setAs={setAs} />
-          </ToolbarItem>
+          <ToolbarSMLToggle sml={sml} setSML={setSML} />
+          <ToolbarAsToggle as={as} setAs={setAs} />
         </ToolbarGroup>
       </ToolbarContent>
     </Toolbar>

--- a/pdl-live-react/src/view/masonry/ToolbarReplayButton.tsx
+++ b/pdl-live-react/src/view/masonry/ToolbarReplayButton.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useState } from "react"
+import { useLocation, useNavigate } from "react-router"
+
+import { invoke } from "@tauri-apps/api/core"
+
+import { Button, Tooltip } from "@patternfly/react-core"
+
+type Props = {
+  block: import("../../pdl_ast").PdlBlock
+  setValue(value: string): void
+}
+
+export default function ToolbarReplayButton({ block, setValue }: Props) {
+  const { hash } = useLocation()
+  const navigate = useNavigate()
+  const [isReplaying, setIsReplaying] = useState(false)
+
+  const handleClickSource = useCallback(async () => {
+    setIsReplaying(true)
+    try {
+      const newTrace = (await invoke("replay", {
+        trace: JSON.stringify(block),
+      })) as string
+      console.log("new trace", newTrace)
+      setValue(newTrace)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setIsReplaying(false)
+    }
+  }, [hash, navigate, setIsReplaying])
+
+  return (
+    <Tooltip content="Re-run this program">
+      <Button
+        spinnerAriaLabel="Replaying program"
+        spinnerAriaValueText="Replaying"
+        isLoading={isReplaying}
+        onClick={handleClickSource}
+      >
+        Run
+      </Button>
+    </Tooltip>
+  )
+}

--- a/pdl-live-react/src/view/masonry/ToolbarShowSourceButton.tsx
+++ b/pdl-live-react/src/view/masonry/ToolbarShowSourceButton.tsx
@@ -1,26 +1,27 @@
 import { useCallback } from "react"
-import { useLocation, useNavigate } from "react-router"
+import { useLocation, useNavigate, useSearchParams } from "react-router"
 
 import { Button, Tooltip } from "@patternfly/react-core"
+import Icon from "@patternfly/react-icons/dist/esm/icons/code-icon"
 
-import CodeIcon from "@patternfly/react-icons/dist/esm/icons/code-icon"
-
-export default function ToolbarProgramOrSourceToggle() {
+export default function ToolbarShowSourceButton() {
   const { hash } = useLocation()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
-  const handleClickSource = useCallback(() => {
-    navigate("?detail&type=source" + hash)
-  }, [hash, navigate])
+  const onClick = useCallback(() => {
+    if (searchParams.has("detail") && searchParams.get("type") === "source") {
+      // close detail
+      navigate(hash)
+    } else {
+      // open detail
+      navigate("?detail&type=source" + hash)
+    }
+  }, [hash, navigate, searchParams])
 
   return (
     <Tooltip content="Show program source">
-      <Button
-        size="sm"
-        variant="secondary"
-        icon={<CodeIcon />}
-        onClick={handleClickSource}
-      />
+      <Button variant="secondary" icon={<Icon />} onClick={onClick} />
     </Tooltip>
   )
 }


### PR DESCRIPTION
Limitations:
- programs with user input will probably hang
- for now, only re-running the entire program is supported
- while re-running, the only visual feedback is a spinner inside the Run button

TODOs:
- we should present a timestamp somewhere of when the trace was last updated
- we could stream console output somehow to the UI
- we could also stream ollama server output to the UI

![pdl-live-react-run-button](https://github.com/user-attachments/assets/1048c540-1aee-4663-95bf-40dae0d4aba8)
