### PR TITLE
feat: add homebrew formula

### DIFF
--- a/Formula/README.md
+++ b/Formula/README.md
@@ -1,0 +1,5 @@
+This directory houses the [Homebrew](https://brew.sh/) formula that enables users to:
+
+```shell
+brew install IBM/prompt-declaration-language/pdl
+```

--- a/Formula/pdl.rb
+++ b/Formula/pdl.rb
@@ -1,0 +1,16 @@
+cask "pdl" do
+  version "0.3.0"
+
+  name "pdl"
+  desc "PDL is a declarative language designed for developers to create reliable, composable LLM prompts and integrate them into software systems."
+  homepage "https://github.com/IBM/prompt-declaration-language"
+
+  url "https://github.com/IBM/prompt-declaration-language/releases/download/v#{version}/PDL_#{version}_universal.dmg"
+  sha256 "35dcb304ea7355e4daa8330eab0500a1b754ffb6c7ac747a19f8783422dd6f1f"
+  app "PDL.app"
+
+  # auto_updates true
+  binary "#{appdir}/PDL.app/Contents/MacOS/PDL", target: "pdlv"
+
+  zap trash: "~/Library/Application\ Support/PDL"
+end

--- a/pdl-live-react/package.json
+++ b/pdl-live-react/package.json
@@ -1,9 +1,12 @@
 {
   "name": "PDL",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
+    "prod:mac:1": "npm run tauri build -- --no-bundle --target=universal-apple-darwin",
+    "prod:mac:2": "npm run tauri bundle -- --bundles dmg --target universal-apple-darwin",
+    "prod:mac": "npm run prod:mac:1 && npm run prod:mac:2",
     "dev": "vite",
     "build": "tsc && vite build",
     "build:app": "npm run prep_interpreter && npm run tauri build",

--- a/pdl-live-react/src-tauri/tauri.conf.json
+++ b/pdl-live-react/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PDL",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "identifier": "com.ibm.prompt-declaration-language.app",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -46,9 +46,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": {
-      "../.venv/": "interpreter/"
-    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/pdl-live-react/src/view/masonry/Toolbar.tsx
+++ b/pdl-live-react/src/view/masonry/Toolbar.tsx
@@ -2,7 +2,7 @@ import { Toolbar, ToolbarGroup, ToolbarContent } from "@patternfly/react-core"
 
 import ToolbarAsToggle from "./ToolbarAsToggle"
 import ToolbarSMLToggle from "./ToolbarSMLToggle"
-import ToolbarReplayButton from "./ToolbarReplayButton"
+// import ToolbarReplayButton from "./ToolbarReplayButton"
 import ToolbarShowSourceButton from "./ToolbarShowSourceButton"
 
 const alignEnd = { default: "alignEnd" as const }
@@ -26,14 +26,14 @@ export default function MasonryToolbar({
   setAs,
   sml,
   setSML,
-  block,
-  setValue,
+  // block,
+  // setValue,
 }: Props) {
   return (
     <Toolbar className="pdl-masonry-toolbar">
       <ToolbarContent>
         <ToolbarGroup variant="action-group-plain">
-          <ToolbarReplayButton block={block} setValue={setValue} />
+          {/*<ToolbarReplayButton block={block} setValue={setValue} />*/}
           <ToolbarShowSourceButton />
         </ToolbarGroup>
         <ToolbarGroup align={alignEnd} variant="action-group">


### PR DESCRIPTION
This also (for now) disables the Run button in the react ui, and disables packaging of the interpreter. Doing so currently results in notarization failures (macos) due to the interpreter resources not being signed. So we'll need to figure thatout before we can re-enable Run.