### PR TITLE
feat: in react ui re-enable Replay/Run button and functionality

### DIFF
--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "PDL"
 version = "0.1.0"
 dependencies = [
+ "file_diff",
  "serde",
  "serde_json",
  "tauri",
@@ -1083,6 +1084,12 @@ dependencies = [
  "memoffset",
  "rustc_version",
 ]
+
+[[package]]
+name = "file_diff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
 
 [[package]]
 name = "flate2"

--- a/pdl-live-react/src-tauri/Cargo.toml
+++ b/pdl-live-react/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 tempdir = "0.3.7"
 urlencoding = "2.1.3"
 tempfile = "3.16.0"
+file_diff = "1.0.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-cli = "2"

--- a/pdl-live-react/src-tauri/src/cli/run.rs
+++ b/pdl-live-react/src-tauri/src/cli/run.rs
@@ -1,18 +1,91 @@
-use std::fs::read;
+use file_diff::diff;
+use std::fs::{copy, create_dir_all, read};
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
+
+use tauri::path::BaseDirectory;
+use tauri::Manager;
+
+#[cfg(desktop)]
+fn pip_install_if_needed(app_handle: tauri::AppHandle) -> Result<String, tauri::Error> {
+    let cache_path = app_handle.path().cache_dir()?.join("pdl");
+
+    create_dir_all(&cache_path)?;
+    let venv_path = cache_path.join("interpreter-python");
+    let activate_path = venv_path
+        .join("bin/activate")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    let cached_requirements_path = venv_path
+        .join("requirements.txt")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    /* println!(
+        "RUN PATHS activate={:?} cached_reqs={:?}",
+        activate_path, cached_requirements_path
+    ); */
+
+    if !venv_path.exists() {
+        println!("Creating virtual environment...");
+        let venv_path_string = venv_path.into_os_string().into_string().unwrap();
+        let output = Command::new("python3.12")
+            .args(["-mvenv", venv_path_string.as_str()])
+            .output()
+            .expect("Failed to execute venv creation");
+        println!("{:?}", output);
+    }
+
+    let requirements_path = app_handle
+        .path()
+        .resolve("interpreter/requirements.txt", BaseDirectory::Resource)?
+        .into_os_string()
+        .into_string()
+        .unwrap();
+
+    if !diff(
+        requirements_path.as_str(),
+        cached_requirements_path.as_str(),
+    ) {
+        println!("Running pip install...");
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                format!(
+                    "source {activate} && pip install -r {requirements}",
+                    activate = activate_path,
+                    requirements = requirements_path
+                )
+                .as_str(),
+            ])
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdout = child.stdout.take().unwrap();
+
+        // Stream output.
+        let lines = BufReader::new(stdout).lines();
+        for line in lines {
+            println!("{}", line.unwrap());
+        }
+
+        copy(requirements_path, cached_requirements_path)?;
+    }
+
+    Ok(activate_path)
+}
 
 #[cfg(desktop)]
 pub fn run_pdl_program(
     source_file_path: String,
-    interpreter_path: PathBuf,
+    app_handle: tauri::AppHandle,
     trace: bool,
 ) -> Result<Option<Vec<u8>>, tauri::Error> {
     println!("Running {:?}", source_file_path);
-    //let interp = interpreter_path.display().to_string()
-    let activate = interpreter_path.join("bin/activate").display().to_string();
+    let activate = pip_install_if_needed(app_handle)?;
 
     let (trace_file, trace_arg) = if trace {
         let f = NamedTempFile::new()?;

--- a/pdl-live-react/src-tauri/src/cli/setup.rs
+++ b/pdl-live-react/src-tauri/src/cli/setup.rs
@@ -4,8 +4,6 @@ use std::process::exit;
 use serde_json::Value;
 use urlencoding::encode;
 
-use tauri::path::BaseDirectory;
-use tauri::Manager;
 use tauri_plugin_cli::CliExt;
 
 use crate::cli::run;
@@ -24,13 +22,9 @@ pub fn cli(app: &mut tauri::App) -> Result<(), tauri::Error> {
                 "run" => {
                     if let Some(source) = subcommand_matches.matches.args.get("source") {
                         if let Value::String(source_file_path) = &source.value {
-                            let interpreter_path = app
-                                .path()
-                                .resolve("interpreter/", BaseDirectory::Resource)?;
-
                             run::run_pdl_program(
                                 source_file_path.clone(),
-                                interpreter_path,
+                                app.handle().clone(),
                                 false,
                             )?;
                             exit(0)

--- a/pdl-live-react/src-tauri/src/commands/replay.rs
+++ b/pdl-live-react/src-tauri/src/commands/replay.rs
@@ -2,9 +2,6 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 //use tauri::ipc::Response;
 
-use tauri::path::BaseDirectory;
-use tauri::Manager;
-
 use crate::cli::run::run_pdl_program;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -14,15 +11,10 @@ pub async fn replay(app_handle: tauri::AppHandle, trace: String) -> Result<Strin
     file.write_all(trace.as_bytes())
         .map_err(|e| e.to_string())?;
 
-    let interpreter_path = app_handle
-        .path()
-        .resolve("interpreter/", BaseDirectory::Resource)
-        .map_err(|e| e.to_string())?;
-
     match file.path().to_str() {
         Some(path) => {
-            let data = run_pdl_program(path.to_string(), interpreter_path, true)
-                .map_err(|e| e.to_string())?;
+            let data =
+                run_pdl_program(path.to_string(), app_handle, true).map_err(|e| e.to_string())?;
             match data {
                 Some(bytes) => {
                     let string = String::from_utf8(bytes).expect("Our bytes should be valid utf8");

--- a/pdl-live-react/src-tauri/tauri.conf.json
+++ b/pdl-live-react/src-tauri/tauri.conf.json
@@ -46,6 +46,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "../.venv/requirements.txt": "interpreter/requirements.txt"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/pdl-live-react/src/view/masonry/Toolbar.tsx
+++ b/pdl-live-react/src/view/masonry/Toolbar.tsx
@@ -2,7 +2,7 @@ import { Toolbar, ToolbarGroup, ToolbarContent } from "@patternfly/react-core"
 
 import ToolbarAsToggle from "./ToolbarAsToggle"
 import ToolbarSMLToggle from "./ToolbarSMLToggle"
-// import ToolbarReplayButton from "./ToolbarReplayButton"
+import ToolbarReplayButton from "./ToolbarReplayButton"
 import ToolbarShowSourceButton from "./ToolbarShowSourceButton"
 
 const alignEnd = { default: "alignEnd" as const }
@@ -26,14 +26,14 @@ export default function MasonryToolbar({
   setAs,
   sml,
   setSML,
-  // block,
-  // setValue,
+  block,
+  setValue,
 }: Props) {
   return (
     <Toolbar className="pdl-masonry-toolbar">
       <ToolbarContent>
         <ToolbarGroup variant="action-group-plain">
-          {/*<ToolbarReplayButton block={block} setValue={setValue} />*/}
+          <ToolbarReplayButton block={block} setValue={setValue} />
           <ToolbarShowSourceButton />
         </ToolbarGroup>
         <ToolbarGroup align={alignEnd} variant="action-group">


### PR DESCRIPTION
I had to disable this temporarily as the prior implementation was blocking macos notarization. With this update, instead of inlining an entire venv as a tauri resource, we inline only the requirements.txt.