### PR TITLE
fix: in react ui, tweak colors to avoid purple-teal combo

### DIFF
--- a/pdl-live-react/src/view/masonry/Masonry.css
+++ b/pdl-live-react/src/view/masonry/Masonry.css
@@ -46,10 +46,10 @@
     background: #daf2f2;
   }
   &[data-kind="read"] {
-    background: #ffe8cc;
+    background: #e9f7df;
   }
   &[data-kind="code"] {
-    background: #ece6ff;
+    background: #ffe8cc;
   }
 }
 

--- a/pdl-live-react/src/view/memory/Node.tsx
+++ b/pdl-live-react/src/view/memory/Node.tsx
@@ -17,9 +17,9 @@ const CustomNode: FunctionComponent<CustomNodeProps> = (
   const label = props.element.getLabel()
   const badge = ordinal
   const badgeColor = /Read/.test(label)
-    ? "var(--pf-t--global--color--nonstatus--orange--default)"
+    ? "var(--pf-t--global--color--nonstatus--green--default)"
     : /Code/.test(label)
-      ? "var(--pf-t--global--color--nonstatus--purple--default)"
+      ? "var(--pf-t--global--color--nonstatus--orange--default)"
       : /LLM/.test(label)
         ? "var(--pf-t--global--color--nonstatus--teal--default)"
         : "var(--pf-t--color--white)"

--- a/pdl-live-react/src/view/timeline/Timeline.css
+++ b/pdl-live-react/src/view/timeline/Timeline.css
@@ -84,10 +84,10 @@
     background-color: var(--pf-t--global--icon--color--disabled);
   }
   &[data-kind="code"] {
-    background-color: var(--pf-t--global--color--nonstatus--purple--default);
+    background-color: var(--pf-t--global--color--nonstatus--orange--default);
   }
   &[data-kind="read"] {
-    background-color: var(--pf-t--global--color--nonstatus--orange--default);
+    background-color: var(--pf-t--global--color--nonstatus--green--default);
   }
   &[data-kind="repeat"],
   &[data-kind="lastOf"],


### PR DESCRIPTION
A common combination is LLM + Code, which had been using teal + purple. This changes that to teal + orange, which i think is a more contemporary pair. Read blocks had been orange, and they are now green.