### PR TITLE
fix: in react ui, topology is often partially off-viewport

### DIFF
--- a/pdl-live-react/src/view/memory/Topology.tsx
+++ b/pdl-live-react/src/view/memory/Topology.tsx
@@ -35,6 +35,7 @@ export default function Topology({ sml, nodes, edges, numbering }: Props) {
     newController.registerComponentFactory(componentFactory)
 
     newController.addEventListener(SELECTION_EVENT, setSelectedIds)
+    newController.setFitToScreenOnLayout(true, 60)
     return newController
   }, [])
 


### PR DESCRIPTION
This seems to be a bug in `@patternfly/react-topology`... This introduces a workaround, by asking the topology controller to `setFitToScreenOnLayout(true)`. This introduces a different quirk, in which the topology renders (off-viewport) and then immediately shifts and resizes. Sigh. I don't know of a way (yet) to ask the topology logic to render off screen (to get its size) and only then render on-screen. But this quirk seems preferably to having the topology render mostly off-viewport.