### PR TITLE
fix: react ui Timeline tree spine vertical gap

### DIFF
--- a/pdl-live-react/src/view/masonry/Duration.css
+++ b/pdl-live-react/src/view/masonry/Duration.css
@@ -1,4 +1,4 @@
 .pdl-duration {
-  font-size: 0.75em;
+  font-size: 0.875em;
   cursor: default;
 }

--- a/pdl-live-react/src/view/masonry/Masonry.css
+++ b/pdl-live-react/src/view/masonry/Masonry.css
@@ -29,7 +29,6 @@
 
   &[data-is-non-card] {
     padding: 1em;
-    &[data-padding="s"],
     &[data-padding="m"],
     &[data-padding="l"] {
       column-span: all;

--- a/pdl-live-react/src/view/timeline/Timeline.css
+++ b/pdl-live-react/src/view/timeline/Timeline.css
@@ -1,4 +1,5 @@
 .pdl-timeline {
+  --pdl-t-h: 1em;
   display: table;
   border-collapse: collapse;
 
@@ -14,9 +15,11 @@
   vertical-align: middle;
 
   &[data-cell="kind"] {
-    height: 1.25em;
-    line-height: 1.25em;
+    height: var(--pdl-t-h);
+    line-height: var(--pdl-t-h);
     .pdl-mono {
+      line-height: 1em;
+      font-size: 1.125em; /* eliminate vertical gaps in tree spine characters */
       white-space: pre;
     }
   }
@@ -37,6 +40,12 @@
   }
 }
 
+.pdl-timeline-bar-outer,
+.pdl-timeline-cell[data-cell="duration"] {
+  height: var(--pdl-t-h);
+  line-height: var(--pdl-t-h);
+}
+
 /* Link hover effects */
 .pdl-timeline-row:hover {
   .pdl-timeline-kind a {
@@ -44,16 +53,22 @@
   }
 }
 
+/** Hide timeline bar and duration cells in S mode */
+.pdl-masonry-tile[data-padding="s"] {
+  .pdl-timeline-bar-outer,
+  .pdl-timeline-cell[data-cell="duration"] {
+    display: none;
+  }
+}
+
 .pdl-timeline-bar-outer {
   width: 100%;
   position: relative;
   display: block;
-  height: 1.25em;
-  line-height: 1.25em;
 }
 
 .pdl-timeline-bar {
-  height: 1em;
+  height: var(--pdl-t-h);
   position: absolute;
   min-width: 1px;
 


### PR DESCRIPTION
This also updates S display mode to show only the tree, not the timeline bars or duration.