### PR TITLE
fix: in react ui, improve display of masonry tiles via use of panel

### DIFF
--- a/pdl-live-react/src/view/Result.tsx
+++ b/pdl-live-react/src/view/Result.tsx
@@ -27,7 +27,7 @@ export default function Result({
   const isCode = !!lang && lang !== "plaintext" && !!result
 
   const innerContent = isCode ? (
-    <Code block={result} language={lang} />
+    <Code block={result} language={lang} wrap={false} />
   ) : (
     <Value>{result}</Value>
   )

--- a/pdl-live-react/src/view/Value.tsx
+++ b/pdl-live-react/src/view/Value.tsx
@@ -1,5 +1,4 @@
 import Markdown from "./Markdown"
-import { isMarkdownish } from "../helpers"
 
 type Props = { children: number | string | unknown }
 
@@ -9,11 +8,7 @@ export default function Value({ children: s }: Props) {
       {typeof s === "number" ? (
         s
       ) : typeof s === "string" ? (
-        isMarkdownish(s) ? (
-          <Markdown>{s}</Markdown>
-        ) : (
-          <span className="pdl-wrap">{s.trim()}</span>
-        )
+        <Markdown>{s === "\n" ? "*<newline>*" : s.trim()}</Markdown>
       ) : (
         JSON.stringify(s, undefined, 2)
       )}

--- a/pdl-live-react/src/view/code/Code.tsx
+++ b/pdl-live-react/src/view/code/Code.tsx
@@ -19,6 +19,7 @@ type Props = {
   block: PdlBlock
   language?: SupportedLanguage
   showLineNumbers?: boolean
+  wrap?: boolean
   limitHeight?: boolean
   raw?: boolean
 }
@@ -26,12 +27,15 @@ type Props = {
 export default function Code({
   block,
   language = "yaml",
-  showLineNumbers = false,
+  showLineNumbers,
+  wrap,
   raw = false,
 }: Props) {
   const value =
     typeof block === "string"
-      ? block
+      ? language === "json"
+        ? JSON.stringify(JSON.parse(block), undefined, 2)
+        : block
       : stringify(raw ? block : block_code_cleanup(block))
 
   return (
@@ -39,7 +43,8 @@ export default function Code({
       <PreviewLight
         value={value}
         language={language || "yaml"}
-        showLineNumbers={showLineNumbers ?? false}
+        wrap={wrap}
+        showLineNumbers={showLineNumbers}
       />
     </Suspense>
   )

--- a/pdl-live-react/src/view/code/PreviewLight.tsx
+++ b/pdl-live-react/src/view/code/PreviewLight.tsx
@@ -16,9 +16,10 @@ type Props = {
   value: string
   language: SupportedLanguage
   showLineNumbers?: boolean
+  wrap?: boolean
 }
 
-export default function PreviewLight({ language, value }: Props) {
+export default function PreviewLight({ language, value, wrap = true }: Props) {
   useEffect(() => {
     SyntaxHighlighter.registerLanguage("json", json)
     SyntaxHighlighter.registerLanguage("yaml", yaml)
@@ -31,6 +32,7 @@ export default function PreviewLight({ language, value }: Props) {
       className="pdl-preview-light"
       style={style}
       language={language}
+      wrapLongLines={wrap}
     >
       {value}
     </SyntaxHighlighter>

--- a/pdl-live-react/src/view/detail/RawTraceTabContent.tsx
+++ b/pdl-live-react/src/view/detail/RawTraceTabContent.tsx
@@ -2,5 +2,5 @@ import Code from "../code/Code"
 import { type NonScalarPdlBlock as Model } from "../../helpers"
 
 export default function RawTraceTabContent({ block }: { block: Model }) {
-  return <Code block={block} showLineNumbers raw />
+  return <Code block={block} showLineNumbers raw wrap={false} />
 }

--- a/pdl-live-react/src/view/detail/SourceTabContent.tsx
+++ b/pdl-live-react/src/view/detail/SourceTabContent.tsx
@@ -2,5 +2,5 @@ import Code from "../code/Code"
 import { type NonScalarPdlBlock as Model } from "../../helpers"
 
 export default function SourceTabContent({ block }: { block: Model }) {
-  return <Code block={block} showLineNumbers />
+  return <Code block={block} showLineNumbers wrap={false} />
 }

--- a/pdl-live-react/src/view/masonry/Masonry.css
+++ b/pdl-live-react/src/view/masonry/Masonry.css
@@ -77,7 +77,6 @@
     font-size: 1.25em;
   }
   &[data-padding="s"] {
-    max-height: 20em;
     h1,
     h2,
     h3,
@@ -90,10 +89,6 @@
     }
   }
   &[data-padding="m"] {
-    max-height: 30em;
     font-size: 0.875rem !important;
-  }
-  &[data-padding="l"] {
-    max-height: 40em;
   }
 }

--- a/pdl-live-react/src/view/masonry/MasonryCombo.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryCombo.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
-import { LogViewer } from "@patternfly/react-log-viewer"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  lazy,
+  Suspense,
+} from "react"
 import {
   Button,
   BackToTop,
@@ -10,6 +16,12 @@ import {
   PageSection,
   Stack,
 } from "@patternfly/react-core"
+
+const LogViewer = lazy(() =>
+  import("@patternfly/react-log-viewer").then((m) => ({
+    default: m.LogViewer,
+  })),
+)
 
 //import Topology from "../memory/Topology"
 //import extractVariables from "../memory/model"
@@ -100,28 +112,32 @@ export default function MasonryCombo({ value, setValue }: Props) {
 
       <BackToTop scrollableSelector=".pdl-masonry-page-section" />
 
-      <Modal variant="medium" isOpen={!!modalContent} onClose={closeModal}>
-        <ModalHeader title={modalContent?.header} />
-        <ModalBody tabIndex={0}>
-          <LogViewer
-            hasLineNumbers={false}
-            data={modalContent?.body}
-            theme="dark"
-            scrollToRow={Number.MAX_VALUE}
-          />
-        </ModalBody>
+      {modalContent && (
+        <Modal variant="medium" isOpen={!!modalContent} onClose={closeModal}>
+          <ModalHeader title={modalContent?.header} />
+          <ModalBody tabIndex={0}>
+            <Suspense fallback={<div />}>
+              <LogViewer
+                hasLineNumbers={false}
+                data={modalContent?.body}
+                theme="dark"
+                scrollToRow={Number.MAX_VALUE}
+              />
+            </Suspense>
+          </ModalBody>
 
-        <ModalFooter>
-          <Button
-            key="Close"
-            variant="primary"
-            onClick={closeModal}
-            isDisabled={!modalContent?.done}
-          >
-            Close
-          </Button>
-        </ModalFooter>
-      </Modal>
+          <ModalFooter>
+            <Button
+              key="Close"
+              variant="primary"
+              onClick={closeModal}
+              isDisabled={!modalContent?.done}
+            >
+              Close
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
     </>
   )
 }

--- a/pdl-live-react/src/view/masonry/MasonryTile.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryTile.tsx
@@ -6,7 +6,8 @@ import {
   CardTitle,
   CardBody,
   Flex,
-  Stack,
+  Panel,
+  PanelMain,
 } from "@patternfly/react-core"
 
 import Result from "../Result"
@@ -53,11 +54,20 @@ export default function MasonryTile({
     [start_nanos, end_nanos, timezone, sml],
   )
 
+  const maxHeight =
+    sml === "s"
+      ? "20em"
+      : sml === "m"
+        ? "30em"
+        : sml === "l"
+          ? "40em"
+          : undefined
+
   return (
     <Card
       isPlain
       isLarge={sml === "xl"}
-      isCompact={sml === "s" || sml === "m"}
+      isCompact={sml === "s"}
       key={id}
       data-kind={kind}
       data-padding={sml}
@@ -85,10 +95,19 @@ export default function MasonryTile({
       </CardHeader>
 
       <CardBody className="pdl-masonry-tile-body">
-        <Stack>
-          {message && <i>{message}</i>}
-          <Result term="" result={content} lang={lang} />
-        </Stack>
+        <Panel
+          isScrollable={sml !== "xl"}
+          variant="raised"
+          className="pdl-masonry-tile-panel"
+        >
+          <PanelMain maxHeight={maxHeight}>
+            <Result
+              term=""
+              result={message ? `*${message.trim()}*\n\n${content}` : content}
+              lang={lang}
+            />
+          </PanelMain>
+        </Panel>
       </CardBody>
     </Card>
   )


### PR DESCRIPTION
- raised panel to better offset content inside tile
- improved inner scrolling, with the scrollbars hugging the perimeter of the tile
- some related improvements to display of markdown-like content inside tiles

![pdl-live-react-masonry-v8](https://github.com/user-attachments/assets/9a023ce1-e25d-46af-88db-fe9e0e3dfa46)

