### PR TITLE
fix: in react ui, close drawer when switching to a different trace

### DIFF
--- a/pdl-live-react/src/page/Sidebar.tsx
+++ b/pdl-live-react/src/page/Sidebar.tsx
@@ -15,6 +15,11 @@ export default function Sidebar() {
   const { hash, pathname: activeItem } = useLocation()
 
   const [searchParams] = useSearchParams()
+  searchParams.delete("id")
+  searchParams.delete("def")
+  searchParams.delete("get")
+  searchParams.delete("type")
+  searchParams.delete("detail")
   const s = searchParams.toString()
   const search = (s.length > 0 ? "?" + s : "") + hash
 


### PR DESCRIPTION
The drawer content will be specific to a trace...