### PR TITLE
fix: in react ui, timeline tree sometimes has dangling last child spines

### DIFF
--- a/pdl-live-react/src/view/timeline/Timeline.css
+++ b/pdl-live-react/src/view/timeline/Timeline.css
@@ -1,5 +1,5 @@
 .pdl-timeline {
-  --pdl-t-h: 1em;
+  --pdl-t-h: 1.125em;
   display: table;
   border-collapse: collapse;
 
@@ -18,8 +18,6 @@
     height: var(--pdl-t-h);
     line-height: var(--pdl-t-h);
     .pdl-mono {
-      line-height: 1em;
-      font-size: 1.125em; /* eliminate vertical gaps in tree spine characters */
       white-space: pre;
     }
   }

--- a/pdl-live-react/src/view/timeline/model.ts
+++ b/pdl-live-react/src/view/timeline/model.ts
@@ -111,7 +111,13 @@ export function childrenOf(block: NonScalarPdlBlock) {
     .filter(nonNullable)
 }
 
-function positionOf(row: TimelineRow, idx: number, A: TimelineRow[]): Position {
+function positionOf(row: TimelineRow): Position {
+  if (!row.parent) {
+    return "push"
+  }
+
+  const A = row.parent.children
+  const idx = A.findIndex((c) => c === row)
   return idx === A.length - 1 || A[idx + 1].depth < row.depth
     ? "pop"
     : idx === 0 || A[idx - 1].depth < row.depth
@@ -161,7 +167,7 @@ export function pushPopsFor(model: TimelineRow[]): PushPop[] {
     const root = model[rootIdx]
     const mine = {
       prefix: prefix.slice(0),
-      position: positionOf(root, rootIdx, model),
+      position: positionOf(root),
     }
     result.push(mine)
 


### PR DESCRIPTION
This also improves the line-height rendering.