### PR TITLE
fix: react ui timeline bars need a bit of vertical separation

### DIFF
--- a/pdl-live-react/src/view/timeline/Timeline.css
+++ b/pdl-live-react/src/view/timeline/Timeline.css
@@ -66,9 +66,9 @@
 }
 
 .pdl-timeline-bar {
-  height: var(--pdl-t-h);
+  height: calc(0.825 * var(--pdl-t-h));
   position: absolute;
-  min-width: 1px;
+  min-width: 0.25em;
 
   a {
     /* This is the link that allows drilldown clicks from the bar */


### PR DESCRIPTION
This also increases bar min-width from 1px to 0.25em.