### PR TITLE
fix: improve padding/spacing in react ui Welcome page

### DIFF
--- a/pdl-live-react/src/page/Page.tsx
+++ b/pdl-live-react/src/page/Page.tsx
@@ -1,7 +1,6 @@
+import { Page } from "@patternfly/react-core"
 import { useSearchParams } from "react-router"
 import { useEffect, useState } from "react"
-
-import { Page, PageSection } from "@patternfly/react-core"
 
 import Sidebar from "./Sidebar"
 import MasonryCombo from "../view/masonry/MasonryCombo"
@@ -15,21 +14,15 @@ import {
 
 import "./Page.css"
 
-const withPadding = { default: "padding" as const }
-const withoutPadding = { default: "noPadding" as const }
-
 type Props = import("react").PropsWithChildren<
   PageBreadcrumbProps & {
-    /** Should the page content use default padding? [default: true] */
-    padding?: boolean
-
     /** The initial trace content */
     initialValue?: string
   }
 >
 
 export default function PDLPage(props: Props) {
-  const { padding = true, initialValue, children } = props
+  const { initialValue, children } = props
 
   useEffect(() => setDarkModeForSession(getDarkModeUserSetting()), [])
 
@@ -59,20 +52,10 @@ export default function PDLPage(props: Props) {
         />
       }
     >
-      {!children ? (
-        value &&
-        value.length > 0 && <MasonryCombo value={value} setValue={setValue} />
-      ) : (
-        <PageSection
-          isFilled
-          hasOverflowScroll
-          padding={padding ? withPadding : withoutPadding}
-          className="pdl-content-section"
-          aria-label="PDL Viewer main section"
-        >
-          {children}
-        </PageSection>
-      )}
+      {!children
+        ? value &&
+          value.length > 0 && <MasonryCombo value={value} setValue={setValue} />
+        : children}
     </Page>
   )
 }

--- a/pdl-live-react/src/page/PageBreadcrumbs.tsx
+++ b/pdl-live-react/src/page/PageBreadcrumbs.tsx
@@ -31,16 +31,22 @@ export default function PageBreadcrumbs({
     [breadcrumb1],
   )
 
+  const homeIsLink = !!breadcrumb1 || !!breadcrumb2
+
   return (
     <Breadcrumb>
       <BreadcrumbItem>PDL</BreadcrumbItem>
-      <BreadcrumbItem render={renderHome} />
+      {homeIsLink ? (
+        <BreadcrumbItem render={renderHome} />
+      ) : (
+        <BreadcrumbItem isActive>Home</BreadcrumbItem>
+      )}
       {breadcrumb1 && !breadcrumb2 ? (
         <BreadcrumbItem>{breadcrumb1}</BreadcrumbItem>
       ) : (
-        <BreadcrumbItem render={renderFirst} />
+        breadcrumb1 && <BreadcrumbItem render={renderFirst} />
       )}
-      {breadcrumb2 && <BreadcrumbItem>{breadcrumb2}</BreadcrumbItem>}
+      {breadcrumb2 && <BreadcrumbItem isActive>{breadcrumb2}</BreadcrumbItem>}
     </Breadcrumb>
   )
 }

--- a/pdl-live-react/src/page/welcome/Welcome.tsx
+++ b/pdl-live-react/src/page/welcome/Welcome.tsx
@@ -1,13 +1,5 @@
 import { type ReactNode } from "react"
-import {
-  Content,
-  PageSection,
-  Panel,
-  PanelFooter,
-  PanelHeader,
-  PanelMain,
-  PanelMainBody,
-} from "@patternfly/react-core"
+import { Flex, FlexItem, PageSection, Title } from "@patternfly/react-core"
 
 import Page from "../Page"
 import Intro from "./Intro"
@@ -17,6 +9,8 @@ import Toolbar from "./Toolbar"
 
 import "./Welcome.css"
 
+const flex1 = { default: "flex_1" as const }
+
 type Props = {
   breadcrumb1?: string
   intro?: ReactNode
@@ -25,27 +19,23 @@ type Props = {
 
 export default function Welcome(props: Props) {
   return (
-    <Page breadcrumb1={props.breadcrumb1 ?? "Welcome"} padding={false}>
-      <PageSection type="subnav">
-        <Toolbar />
+    <Page breadcrumb1={props.breadcrumb1}>
+      <PageSection>
+        <Flex>
+          <Title headingLevel="h1">Prompt Declaration Language (PDL)</Title>{" "}
+          <FlexItem flex={flex1}>
+            <Toolbar />
+          </FlexItem>
+        </Flex>
+        {props.intro ?? <Intro />}
       </PageSection>
+
       <PageSection isFilled hasOverflowScroll>
-        <Panel>
-          <PanelHeader>
-            <Content component="h1">Prompt Declaration Language (PDL)</Content>
-            {props.intro ?? <Intro />}
-          </PanelHeader>
+        <Tiles tiles={props.tiles} />
+      </PageSection>
 
-          <PanelMain className="pdl-welcome-content">
-            <PanelMainBody>
-              <Tiles tiles={props.tiles} />
-            </PanelMainBody>
-          </PanelMain>
-
-          <PanelFooter>
-            <Links />
-          </PanelFooter>
-        </Panel>
+      <PageSection>
+        <Links />
       </PageSection>
     </Page>
   )

--- a/pdl-live-react/src/view/masonry/MasonryCombo.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryCombo.tsx
@@ -109,7 +109,7 @@ export default function MasonryCombo({ value, setValue }: Props) {
       <PageSection
         isFilled
         hasOverflowScroll
-        className="pdl-content-section pdl-masonry-page-section"
+        className="pdl-masonry-page-section"
         aria-label="PDL Viewer main section"
       >
         <Stack hasGutter>


### PR DESCRIPTION
This also fixes the breadcrumb for the welcome page to avoid Home > Welcome. Now it will be just Home.