### PR TITLE
fix: improve rendering of empty blocks in react ui

### DIFF
--- a/pdl-live-react/src/helpers.ts
+++ b/pdl-live-react/src/helpers.ts
@@ -164,9 +164,14 @@ export function hasContextInformation(
 }
 
 export function capitalizeAndUnSnakeCase(s: string) {
-  return s === "model"
-    ? "LLM"
-    : s[0].toUpperCase() + s.slice(1).replace(/[-_]/, " ")
+  switch (s) {
+    case "model":
+      return "LLM"
+    case "empty":
+      return "(defs)"
+    default:
+      return s[0].toUpperCase() + s.slice(1).replace(/[-_]/, " ")
+  }
 }
 
 type MessageBearing = Omit<import("./pdl_ast").ReadBlock, "message"> & {

--- a/pdl-live-react/src/view/timeline/model.ts
+++ b/pdl-live-react/src/view/timeline/model.ts
@@ -103,7 +103,9 @@ export function childrenOf(block: NonScalarPdlBlock) {
     .with({ kind: "object" }, (data) => [data.object])
     .with({ kind: "message" }, (data) => [data.content])
     .with({ kind: "repeat" }, (data) => [data.trace ?? data.repeat])
-    .with({ kind: "empty" }, () => [])
+    .with({ kind: "empty" }, (data) =>
+      data.defs ? Object.values(data.defs) : [],
+    )
     .with({ kind: "error" }, () => []) // TODO show errors in trace
     .with({ kind: undefined }, () => [])
     .exhaustive()


### PR DESCRIPTION
We now "unfurl" the defs. Previously in this screenshot, defs -> LLM would show only as Empty.

![Screenshot 2025-02-24 at 12 36 45 PM](https://github.com/user-attachments/assets/d1f2a59f-1664-47d6-b198-b39ecb69d16b)
