### PR TITLE
fix: in react ui, try going back to timeline as part of the masonry grid

### DIFF
--- a/pdl-live-react/src/view/masonry/Masonry.css
+++ b/pdl-live-react/src/view/masonry/Masonry.css
@@ -4,10 +4,10 @@
     column-gap: 0.5em;
   }
   &[data-padding="m"] {
-    columns: 300px;
+    columns: 350px;
   }
   &[data-padding="l"] {
-    columns: 400px;
+    columns: 500px;
   }
   &[data-padding="xl"] {
     columns: 100%;
@@ -24,13 +24,6 @@
 
   &[data-padding="s"] {
     margin-bottom: 0.5em;
-  }
-
-  &[data-variant="plain"] {
-    &[data-padding="m"],
-    &[data-padding="l"] {
-      column-span: all;
-    }
   }
 }
 

--- a/pdl-live-react/src/view/masonry/MasonryCombo.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryCombo.tsx
@@ -14,7 +14,6 @@ import {
   ModalFooter,
   ModalHeader,
   PageSection,
-  Stack,
 } from "@patternfly/react-core"
 
 const RunTerminal = lazy(() => import("../term/RunTerminal"))
@@ -112,25 +111,22 @@ export default function MasonryCombo({ value, setValue }: Props) {
         className="pdl-masonry-page-section"
         aria-label="PDL Viewer main section"
       >
-        <Stack hasGutter>
-          {sml !== "s" && (
-            <MasonryTileWrapper sml={sml} variant="plain">
-              <Timeline model={base} numbering={numbering} />
-            </MasonryTileWrapper>
-          )}
-          <Masonry model={masonry} sml={sml}>
-            {sml === "s" && <Timeline model={base} numbering={numbering} />}
-            {/*(as !== "list" || sml !== "s") && nodes.length > 0 && (
+        <Masonry model={masonry} sml={sml}>
+          <MasonryTileWrapper sml={sml} variant="plain">
+            <Timeline model={base} numbering={numbering} />
+          </MasonryTileWrapper>
+          {/*(as !== "list" || sml !== "s") && nodes.length > 0 && (
             <Topology
               nodes={nodes}
               edges={edges}
               numbering={numbering}
               sml={sml}
             />)*/}
-          </Masonry>
-        </Stack>
+        </Masonry>
       </PageSection>
+
       <BackToTop scrollableSelector=".pdl-masonry-page-section" />
+
       <Modal variant="large" isOpen={!!modalContent} onClose={closeModal}>
         <ModalHeader
           title={modalContent?.header}

--- a/pdl-live-react/src/view/masonry/MasonryTile.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryTile.tsx
@@ -87,11 +87,7 @@ export default function MasonryTile({
 
   return (
     <MasonryTileWrapper sml={sml} kind={kind} header={header}>
-      <Panel
-        isScrollable={sml !== "xl"}
-        variant="raised"
-        className="pdl-masonry-tile-panel"
-      >
+      <Panel isScrollable={sml !== "xl"} className="pdl-masonry-tile-panel">
         <PanelMain maxHeight={maxHeight}>
           <Result
             term=""

--- a/pdl-live-react/src/view/timeline/Timeline.css
+++ b/pdl-live-react/src/view/timeline/Timeline.css
@@ -123,3 +123,17 @@
     }
   }
 }
+
+.pdl-timeline .pdl-masonry-index {
+  font-size: 0.5rem;
+  display: inline-block;
+  margin-right: 0.375em;
+  width: 1.5em;
+  height: 1.5em;
+  line-height: 1.5em;
+}
+
+.pdl-timeline-kind {
+  display: inline-flex;
+  align-items: center;
+}

--- a/pdl-live-react/src/view/timeline/TimelineRowKindCell.tsx
+++ b/pdl-live-react/src/view/timeline/TimelineRowKindCell.tsx
@@ -25,7 +25,7 @@ export default function TimelineRowKindCell({ row, ordinal }: Props) {
 
   return (
     <span className="pdl-timeline-kind">
-      {ordinal ? <strong>{ordinal}. </strong> : ""}
+      {ordinal && <span className="pdl-masonry-index">{ordinal}</span>}
       <Button variant="link" isInline component={link}>
         <span>{capitalizeAndUnSnakeCase(row.block.kind ?? "unknown")}</span>
       </Button>


### PR DESCRIPTION
Hmm... experimenting here... Full-width timelines don't render particular well for the use cases we have so far. They render as just a bunch of very wide awkward bars.

This also updates the timeline to use the (1) circled number UI from the masonry tiles.

![pdl-live-react-masonry-v11](https://github.com/user-attachments/assets/8fa1f680-bff7-4cb3-a995-2cd0bc6c52cf)
