### PR TITLE
doc: update GitHub Pages builder to build and serve react ui

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - "mkdocs.yml"
       - "docs/**"
-      - "pdl-live"
+      - "pdl-live-react"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -46,6 +46,20 @@ jobs:
         run: mkdocs build --config-file ./mkdocs.yml --strict --site-dir ./_site
         env:
           CI: true
+      # Viewer
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        working-directory: ./pdl-live-react
+        run: npm ci
+      - name: Build viewer
+        working-directory: ./pdl-live-react
+        run: npm run build
+      - name: Copy viewer
+        working-directory: ./pdl-live-react
+        run: cp -a ./dist ../docs/viewer        
       # Deploy
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/pdl-live-react/vite.config.ts
+++ b/pdl-live-react/vite.config.ts
@@ -6,6 +6,7 @@ const host = process.env.TAURI_DEV_HOST;
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
+  base:  "./",
   plugins: [
     react(),
     checker({


### PR DESCRIPTION
under `/prompt-declaration-language/viewer`

this does not update the mkdocs pages themselves to reference the viewer. first, let's get the viewer onto github pages...

Closes #446