### PR TITLE
Use stop: instead of stop_sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ text:
 - "write a hello world example\n"
 - model: ollama/granite-code:8b
   parameters:
-    stop_sequences: '!'
+    stop: ['!']
     temperature: 0
 ```
 


### PR DESCRIPTION
For #448

Using `stop_sequences` with Ollama causes Ollama to log a warning about an unknown parameter.