### PR TITLE
fix: switching between ui demos can lead to funky masonry tiles

### DIFF
--- a/pdl-live-react/src/view/masonry/Masonry.tsx
+++ b/pdl-live-react/src/view/masonry/Masonry.tsx
@@ -23,7 +23,12 @@ export default function Masonry({ sml, model, children }: Props) {
           </div>
         ))}
       {model.map((props, idx) => (
-        <MasonryTile key={props.id} {...props} idx={idx + 1} sml={sml} />
+        <MasonryTile
+          key={props.id + "." + idx}
+          {...props}
+          idx={idx + 1}
+          sml={sml}
+        />
       ))}
     </div>
   )


### PR DESCRIPTION
Due to a bug that lead to two masonry tiles having the same react `key`, switching e.g. from Chatbot to Code Explanation back to Chatbot would lead to blocks bleeding between the second and third...