### PR TITLE
Ensure lazy context

### DIFF
--- a/src/pdl/pdl_notebook_ext.py
+++ b/src/pdl/pdl_notebook_ext.py
@@ -34,7 +34,8 @@ class PDLMagics(Magics):
         if args.reset_context:
             scope = local_ns | {"pdl_context": PdlList([])}
         else:
-            scope = local_ns
+            # local_ns won't be lazy; make it lazy again
+            scope = local_ns | {"pdl_context": PdlList(local_ns.get('pdl_context', []))}
         try:
             pdl_output = exec_str(
                 cell,
@@ -45,7 +46,8 @@ class PDLMagics(Magics):
                 output="all",
             )
         except Exception as err:
-            # Uncomment to show PDL tracebacks during Juypter cell execution
+            # Uncomment to show PDL tracebacks during Jupyter cell execution
+            # import traceback
             # print(traceback.format_exc())
             print(err)
             return

--- a/src/pdl/pdl_notebook_ext.py
+++ b/src/pdl/pdl_notebook_ext.py
@@ -35,7 +35,7 @@ class PDLMagics(Magics):
             scope = local_ns | {"pdl_context": PdlList([])}
         else:
             # local_ns won't be lazy; make it lazy again
-            scope = local_ns | {"pdl_context": PdlList(local_ns.get('pdl_context', []))}
+            scope = local_ns | {"pdl_context": PdlList(local_ns.get("pdl_context", []))}
         try:
             pdl_output = exec_str(
                 cell,


### PR DESCRIPTION
Resolves #561

This handles the case where the user's cell does not include `--reset-context`.

Or Jupyter extension uses the `@needs_local_scope` decorator on our Jupyter cell magic function.  When our function is called our local scope object has non-lazy types.  (That surprised me, because the types seem lazy when we exit the previous cell magic.). This PR ensures a lazy context.