### PR TITLE
fix: adjust release-ui workflow to use repo tag and release naming conventions

### DIFF
--- a/.github/workflows/release-ui.yml
+++ b/.github/workflows/release-ui.yml
@@ -19,7 +19,9 @@ jobs:
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
             args: '--target universal-apple-darwin'
           - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
-            args: ''
+            args: '--target aarch64-unknown-linux-musl'
+          - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: '--target x86_64-unknown-linux-musl'
           - platform: 'windows-latest'
             args: ''
 
@@ -62,9 +64,6 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
-          releaseName: 'App v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
-          prerelease: false
+          tagName: v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'Version __VERSION__ (ui build test)'
           args: ${{ matrix.args }}


### PR DESCRIPTION
And also to build for arm and x86 linux.