### PR TITLE
fix: tweak ui app config so as to produce a lower-case 'pdl' executable

### DIFF
--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -3,25 +3,6 @@
 version = 4
 
 [[package]]
-name = "PDL"
-version = "0.4.1"
-dependencies = [
- "duct",
- "file_diff",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-cli",
- "tauri-plugin-opener",
- "tauri-plugin-pty",
- "tauri-plugin-window-state",
- "tempdir",
- "tempfile",
- "urlencoding",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2621,25 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pdl"
+version = "0.4.1"
+dependencies = [
+ "duct",
+ "file_diff",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-cli",
+ "tauri-plugin-opener",
+ "tauri-plugin-pty",
+ "tauri-plugin-window-state",
+ "tempdir",
+ "tempfile",
+ "urlencoding",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/pdl-live-react/src-tauri/Cargo.toml
+++ b/pdl-live-react/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "PDL"
+name = "pdl"
 version = "0.4.1"
 description = "Prompt Declaration Language"
 authors = ["nickm@us.ibm.com"]

--- a/pdl-live-react/src-tauri/tauri.conf.json
+++ b/pdl-live-react/src-tauri/tauri.conf.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "com.ibm.prompt-declaration-language.app",
+  "productName": "PDL",
+  "mainBinaryName": "pdl",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
We want the package (and macos app bundle) to be named PDL, but we want the actual executable (used on the command line) to be pdl.