### PR TITLE
chore: improve startup time of pdl python

### DIFF
--- a/src/pdl/pdl_granite_io.py
+++ b/src/pdl/pdl_granite_io.py
@@ -1,0 +1,134 @@
+# pylint: disable=import-outside-toplevel
+from asyncio import run_coroutine_threadsafe
+from typing import Any, Optional
+
+from granite_io.types import ChatCompletionInputs
+
+from .pdl_ast import (
+    ErrorBlock,
+    GraniteioModelBlock,
+    LazyMessage,
+    ModelInput,
+    PDLRuntimeError,
+)
+from .pdl_lazy import PdlConst, PdlLazy, lazy_apply
+from .pdl_llms import _LOOP
+
+
+class GraniteioModel:
+    @staticmethod
+    def processor_of_block(block: GraniteioModelBlock):
+        assert isinstance(
+            block.model, str
+        ), f"The model should be a string: {block.model}"
+        assert isinstance(
+            block.backend, (dict, str)
+        ), f"The backend should be a string or a dictionnary: {block.backend}"
+        match block.backend:
+            case {"transformers": device}:
+                assert isinstance(block.backend, dict)
+                from granite_io import make_backend
+
+                backend = make_backend(
+                    "transformers",
+                    {
+                        "model_name": block.model,
+                        "device": device,
+                    },
+                )
+            case backend_name if isinstance(backend_name, str):
+                from granite_io import make_backend
+
+                backend = make_backend(
+                    backend_name,
+                    {
+                        "model_name": block.model,
+                    },
+                )
+            case _:
+                assert False, f"Unexpected backend: {block.backend}"
+        processor_name = block.processor
+        if processor_name is None:
+            processor_name = block.model
+        assert isinstance(
+            processor_name, str
+        ), f"The processor should be a string: {processor_name}"
+        from granite_io import make_io_processor
+
+        io_processor = make_io_processor(processor_name, backend=backend)
+        return io_processor
+
+    @staticmethod
+    def build_message(
+        messages: ModelInput,
+        parameters: Optional[dict[str, Any]],
+    ) -> ChatCompletionInputs:
+        if parameters is None:
+            parameters = {}
+        inputs = {"messages": messages} | parameters
+        return ChatCompletionInputs.model_validate(inputs)
+
+    @staticmethod
+    async def async_generate_text(
+        block: GraniteioModelBlock,
+        messages: ModelInput,
+    ) -> tuple[dict[str, Any], Any]:
+        try:
+            assert block.parameters is None or isinstance(block.parameters, dict)
+            io_processor = GraniteioModel.processor_of_block(block)
+            inputs = GraniteioModel.build_message(messages, block.parameters)
+            result = io_processor.create_chat_completion(inputs)  # pyright: ignore
+            message = result.next_message.model_dump()
+            raw_result = result.model_dump()
+            return (
+                message,
+                raw_result,
+            )
+        except Exception as exc:
+            message = f"Error during '{block.model}' model call: {repr(exc)}"
+            loc = block.location
+            raise PDLRuntimeError(
+                message,
+                loc=loc,
+                trace=ErrorBlock(msg=message, location=loc, program=block),
+            ) from exc
+
+    @staticmethod
+    def generate_text(
+        block: GraniteioModelBlock,
+        messages: ModelInput,
+    ) -> tuple[LazyMessage, PdlLazy[Any]]:
+        future = run_coroutine_threadsafe(
+            GraniteioModel.async_generate_text(
+                block,
+                messages,
+            ),
+            _LOOP,
+        )
+        pdl_future: PdlLazy[tuple[dict[str, Any], Any]] = PdlConst(future)
+        message = lazy_apply((lambda x: x[0]), pdl_future)
+        response = lazy_apply((lambda x: x[1]), pdl_future)
+        return message, response
+
+    # @staticmethod
+    # def generate_text_stream(
+    #     model_id: str,
+    #     messages: ModelInput,
+    #     spec: Any,
+    #     parameters: dict[str, Any],
+    # ) -> Generator[dict[str, Any], Any, Any]:
+    #     parameters = set_structured_decoding_parameters(spec, parameters)
+    #     response = completion(
+    #         model=model_id,
+    #         messages=list(messages),
+    #         stream=True,
+    #         **parameters,
+    #     )
+    #     result = []
+    #     for chunk in response:
+    #         result.append(chunk.json())  # pyright: ignore
+    #         msg = chunk.choices[0].delta  # pyright: ignore
+    #         if msg.role is None:
+    #             msg.role = "assistant"
+    #         yield remove_none_values_from_message(msg.model_dump())
+    #     return result

--- a/src/pdl/pdl_schema_validator.py
+++ b/src/pdl/pdl_schema_validator.py
@@ -1,6 +1,5 @@
+# pylint: disable=import-outside-toplevel
 from typing import Any, Optional
-
-from jsonschema import ValidationError, validate
 
 from .pdl_location_utils import get_loc_string
 from .pdl_schema_error_analyzer import analyze_errors
@@ -40,6 +39,8 @@ def type_check_spec(result: Any, spec: str | dict[str, Any] | list, loc) -> list
 
 
 def type_check(result: Any, schema: dict[str, Any], loc) -> list[str]:
+    from jsonschema import ValidationError, validate
+
     try:
         validate(instance=result, schema=schema)
     except ValidationError as e:


### PR DESCRIPTION
- lazy load litellm
- granite_io startup optimizations by pulling the class into its own file
- lazy load jsonschema

On MacOS this shaves `pdl` (with no arguments) from 1.1s down to 500ms (350ms with the second commit; 330ms with third)
On Windows (Parallels VM on MacOS host), this shaves 6.25s down to 2.1s (1.5s with the second commit; 1.3s with third commit)

@esnible including you because this adjusts the OTEL bits. could you test? thanks

ref https://github.com/BerriAI/litellm/issues/7605