### PR TITLE
fix: pdl_lazy errors out when provided with --data on command line

### DIFF
--- a/src/pdl/pdl_lazy.py
+++ b/src/pdl/pdl_lazy.py
@@ -208,8 +208,14 @@ class PdlApply2(PdlLazy[Apply2OutputT]):
     def result(self) -> Apply2OutputT:
         if self._done:
             return self._data
-        v1 = self.x1.result()
-        v2 = self.x2.result()
+        if isinstance(self.x1, PdlLazy):
+            v1 = self.x1.result()
+        else:
+            v1 = self.x1
+        if isinstance(self.x2, PdlLazy):
+            v2 = self.x2.result()
+        else:
+            v2 = self.x2
         self._data = self.f(v1, v2)
         self._done = True
         return self._data


### PR DESCRIPTION
When running `pdl --data '{"pdl_context": somethingsomething}' prog.pdl`, if prog.pdl is just a model block, it works. If prog.pdl is a text block wrapped around that model block, it fails with

```
  File "/Users/nickm/git/prompt-declaration-language/src/pdl/pdl_interpreter.py", line 438, in process_block_body
    result, background, scope, trace = process_call_model(
                                       ^^^^^^^^^^^^^^^^^^^
  File "/Users/nickm/git/prompt-declaration-language/src/pdl/pdl_interpreter.py", line 1247, in process_call_model
    model_input = scope["pdl_context"]  # pyright: ignore
                  ~~~~~^^^^^^^^^^^^^^^
  File "/Users/nickm/git/prompt-declaration-language/src/pdl/pdl_lazy.py", line 119, in __getitem__
    result = v.result()
             ^^^^^^^^^^
  File "/Users/nickm/git/prompt-declaration-language/src/pdl/pdl_lazy.py", line 211, in result
    v1 = self.x1.result()
         ^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'result'
```