### PR TITLE
fix: in ui, close drawer when switching to a different trace from breadcrumb

### DIFF
--- a/pdl-live-react/src/page/PageBreadcrumbDropdownItem.tsx
+++ b/pdl-live-react/src/page/PageBreadcrumbDropdownItem.tsx
@@ -14,6 +14,11 @@ export default function PageBreadcrumbDropdownItem({
   const navigate = useNavigate()
   const { hash } = useLocation()
   const [searchParams] = useSearchParams()
+  searchParams.delete("id")
+  searchParams.delete("def")
+  searchParams.delete("get")
+  searchParams.delete("type")
+  searchParams.delete("detail")
   const s = searchParams.toString()
   const search = s.length > 0 ? "?" + s : ""
 


### PR DESCRIPTION
See #478 for the related (prior) fix in the Sidebar component.