### PR TITLE
fix: adjust rust cli venv cache path

### DIFF
--- a/pdl-live-react/src-tauri/src/interpreter/pip.rs
+++ b/pdl-live-react/src-tauri/src/interpreter/pip.rs
@@ -15,7 +15,7 @@ pub async fn pip_install_if_needed(
     create_dir_all(&cache_path)?;
 
     let hash = shasum::sha256sum(&requirements_path)?;
-    let venv_path = cache_path.join(hash);
+    let venv_path = cache_path.join("venvs").join(hash);
     let bin_path = venv_path.join(if cfg!(windows) { "Scripts" } else { "bin" });
 
     if !venv_path.exists() {

--- a/pdl-live-react/src-tauri/src/interpreter/shasum.rs
+++ b/pdl-live-react/src-tauri/src/interpreter/shasum.rs
@@ -2,7 +2,7 @@ use ::std::fs::File;
 use ::std::io::{copy, Result};
 use ::std::path::Path;
 
-use base64ct::{Base64, Encoding};
+use base64ct::{Base64Url, Encoding};
 use sha2::{Digest, Sha256};
 
 pub fn sha256sum(path: &Path) -> Result<String> {
@@ -12,5 +12,5 @@ pub fn sha256sum(path: &Path) -> Result<String> {
     copy(&mut file, &mut hasher)?;
     let hash_bytes = hasher.finalize();
 
-    Ok(Base64::encode_string(&hash_bytes))
+    Ok(Base64Url::encode_string(&hash_bytes))
 }


### PR DESCRIPTION
use venv/ dir and use base64 url encoder to avoid / in hash dir name