### PR TITLE
fix: improve padding of detail drawer

### DIFF
--- a/pdl-live-react/src/view/detail/DrawerContent.css
+++ b/pdl-live-react/src/view/detail/DrawerContent.css
@@ -11,11 +11,16 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    padding: 0;
   }
 
   .pf-v6-c-tab-content {
     flex: 1;
     overflow: auto;
+
+    .pf-v6-c-description-list {
+      padding: 1em 2em 0 2em;
+    }
 
     & > pre {
       overflow-x: unset !important;

--- a/pdl-live-react/src/view/detail/DrawerContent.tsx
+++ b/pdl-live-react/src/view/detail/DrawerContent.tsx
@@ -96,7 +96,7 @@ export default function DrawerContent({ value }: Props) {
   }
 
   return (
-    <Card isPlain isLarge className="pdl-drawer-content">
+    <Card isPlain isFullHeight isLarge className="pdl-drawer-content">
       <CardHeader actions={actions}>
         <CardTitle>{header(objectType)}</CardTitle>
         {block && description(block)}


### PR DESCRIPTION
Previously, the detail drawer scrollbars were placed within the padded content. With this change, the scrollbars are flush to the boundaries of the detail drawer.