### PR TITLE
fix: update ui to support pulling interpreter from local dir

### DIFF
--- a/pdl-live-react/requirements.txt
+++ b/pdl-live-react/requirements.txt
@@ -1,2 +1,2 @@
-#-e git+https://github.com/IBM/prompt-declaration-language.git#egg=prompt_declaration_language
-prompt-declaration-language==0.5.0
+-e ../
+#prompt-declaration-language==0.5.0

--- a/pdl-live-react/src-tauri/src/commands/replay_prep.rs
+++ b/pdl-live-react/src-tauri/src/commands/replay_prep.rs
@@ -1,4 +1,5 @@
 use ::std::env::args;
+use ::std::env::current_dir;
 use ::std::io::Write;
 use ::std::path::absolute;
 
@@ -6,7 +7,10 @@ use tempfile::Builder;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
-pub async fn replay_prep(trace: String, name: String) -> Result<(String, String, String), String> {
+pub async fn replay_prep(
+    trace: String,
+    name: String,
+) -> Result<(String, String, String, String), String> {
     let mut input = Builder::new()
         .prefix(&format!("{}-", name))
         .suffix(".pdl")
@@ -30,6 +34,10 @@ pub async fn replay_prep(trace: String, name: String) -> Result<(String, String,
     match (input_path.to_str(), output_path.to_str()) {
         (Some(inny), Some(outty)) => Ok((
             arg0.display().to_string(),
+            current_dir()
+                .map_err(|e| e.to_string())?
+                .display()
+                .to_string(),
             inny.to_string(),
             outty.to_string(),
         )),

--- a/pdl-live-react/src/view/masonry/MasonryCombo.tsx
+++ b/pdl-live-react/src/view/masonry/MasonryCombo.tsx
@@ -84,6 +84,7 @@ export default function MasonryCombo({ value, setValue }: Props) {
   const [modalContent, setModalContent] = useState<null | {
     header: string
     cmd: string
+    cwd: string
     args?: string[]
     onExit?: (exitCode: number) => void
     cancelCondVar?: ConditionVariable
@@ -124,12 +125,12 @@ export default function MasonryCombo({ value, setValue }: Props) {
         return
       }
 
-      const [cmd, input, output] = (await invoke("replay_prep", {
+      const [cmd, cwd, input, output] = (await invoke("replay_prep", {
         trace: JSON.stringify(runThisBlock, (k, v) =>
           /^pdl__/.test(k) ? undefined : v,
         ),
         name: block.description?.slice(0, 30).replace(/\s/g, "-") ?? "trace",
-      })) as [string, string, string]
+      })) as [string, string, string, string]
       console.error(`Replaying with cmd=${cmd} input=${input} output=${output}`)
 
       // We need to pass tothe re-execution the original input context
@@ -141,6 +142,7 @@ export default function MasonryCombo({ value, setValue }: Props) {
         setModalContent({
           header: "Running Program",
           cmd,
+          cwd,
           args: [
             "run",
             ...(async ? ["--stream", "none"] : []),
@@ -252,6 +254,7 @@ export default function MasonryCombo({ value, setValue }: Props) {
           <Suspense fallback={<div />}>
             <RunTerminal
               cmd={modalContent?.cmd ?? ""}
+              cwd={modalContent?.cwd ?? ""}
               args={modalContent?.args}
               cancel={modalContent?.cancelCondVar}
               onExit={onExit}

--- a/pdl-live-react/src/view/term/RunTerminal.tsx
+++ b/pdl-live-react/src/view/term/RunTerminal.tsx
@@ -11,6 +11,9 @@ type Props = {
   /** The cmd part of `cmd ...args` */
   cmd: string
 
+  /** The current working directory in which to run `cmd` */
+  cwd: string
+
   /** The args part of `cmd ...args */
   args?: string[]
 
@@ -21,7 +24,13 @@ type Props = {
   cancel?: import("../masonry/condvar").default
 }
 
-export default function RunTerminal({ cmd, args = [], onExit, cancel }: Props) {
+export default function RunTerminal({
+  cmd,
+  cwd,
+  args = [],
+  onExit,
+  cancel,
+}: Props) {
   const ref = createRef<HTMLDivElement>()
   const [term, setTerm] = useState<null | Terminal>(null)
   const [exitCode, setExitCode] = useState(-1)
@@ -73,6 +82,7 @@ export default function RunTerminal({ cmd, args = [], onExit, cancel }: Props) {
 
       // spawn shell
       const pty = spawn(cmd, args, {
+        cwd,
         cols: term.cols,
         rows: term.rows,
       })


### PR DESCRIPTION
We had been pointing to a remote git branch. To fix this required passing through `cwd` to the pty spawn, because it defaults to using the user's home directory. If we want to use a relative path to the interpreter in our requirements.txt, we need to inherit cwd.