### PR TITLE
fix: interpreter fails when passed parameters with null/None values

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1432,7 +1432,7 @@ def litellm_parameters_to_dict(
     parameters: Optional[LitellmParameters | dict[str, Any]]
 ) -> dict[str, Any]:
     if isinstance(parameters, dict):
-        return parameters
+        return {k: v for k, v in parameters.items() if k != "stream"}
     if parameters is None:
         parameters = LitellmParameters()
     parameters_dict = parameters.model_dump(exclude={"stream"})


### PR DESCRIPTION
> Error during 'ollama/granite3.2:2b' model call: TypeError("litellm.main.completion() got multiple values for keyword argument 'stream'")
