### PR TITLE
Add a new retry feature to `block`

### DIFF
--- a/pdl-live-react/src/pdl_ast.d.ts
+++ b/pdl-live-react/src/pdl_ast.d.ts
@@ -260,6 +260,11 @@ export type Fallback =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -338,6 +343,11 @@ export type Fallback1 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry1 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -449,6 +459,11 @@ export type Fallback2 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry2 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -554,6 +569,11 @@ export type Fallback3 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry3 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -662,6 +682,11 @@ export type Fallback4 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry4 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -751,6 +776,11 @@ export type Fallback5 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry5 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -863,6 +893,11 @@ export type Fallback6 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry6 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -996,6 +1031,11 @@ export type Fallback7 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry7 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1102,6 +1142,11 @@ export type Fallback8 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry8 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1207,6 +1252,11 @@ export type Fallback9 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry9 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -1340,6 +1390,11 @@ export type Fallback10 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry10 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -1528,6 +1583,11 @@ export type Fallback11 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry11 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1673,6 +1733,11 @@ export type Fallback12 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry12 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1815,6 +1880,11 @@ export type Fallback13 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry13 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1894,6 +1964,11 @@ export type Fallback14 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry14 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1972,6 +2047,11 @@ export type Fallback15 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry15 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2053,6 +2133,11 @@ export type Fallback16 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry16 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2163,6 +2248,11 @@ export type Fallback17 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry17 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2311,6 +2401,11 @@ export type Fallback18 =
   | ErrorBlock
   | EmptyBlock
   | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry18 = number | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2496,6 +2591,11 @@ export type Fallback19 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry19 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -2597,6 +2697,11 @@ export type Fallback20 =
   | EmptyBlock
   | null
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry20 = number | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -2697,6 +2802,7 @@ export interface FunctionBlock {
   contribute?: Contribute20
   parser?: Parser20
   fallback?: Fallback20
+  retry?: Retry20
   role?: Role20
   pdl__context?: PdlContext20
   pdl__id?: PdlId20
@@ -2832,6 +2938,7 @@ export interface CallBlock {
   contribute?: Contribute19
   parser?: Parser19
   fallback?: Fallback19
+  retry?: Retry19
   role?: Role19
   pdl__context?: PdlContext19
   pdl__id?: PdlId19
@@ -2898,6 +3005,7 @@ export interface LitellmModelBlock {
   contribute?: Contribute18
   parser?: Parser18
   fallback?: Fallback18
+  retry?: Retry18
   role?: Role18
   pdl__context?: PdlContext18
   pdl__id?: PdlId18
@@ -2965,6 +3073,7 @@ export interface GraniteioModelBlock {
   contribute?: Contribute17
   parser?: Parser17
   fallback?: Fallback17
+  retry?: Retry17
   role?: Role17
   pdl__context?: PdlContext17
   pdl__id?: PdlId17
@@ -3043,6 +3152,7 @@ export interface CodeBlock {
   contribute?: Contribute16
   parser?: Parser16
   fallback?: Fallback16
+  retry?: Retry16
   role?: Role16
   pdl__context?: PdlContext16
   pdl__id?: PdlId16
@@ -3109,6 +3219,7 @@ export interface ArgsBlock {
   contribute?: Contribute15
   parser?: Parser15
   fallback?: Fallback15
+  retry?: Retry15
   role?: Role15
   pdl__context?: PdlContext15
   pdl__id?: PdlId15
@@ -3169,6 +3280,7 @@ export interface GetBlock {
   contribute?: Contribute14
   parser?: Parser14
   fallback?: Fallback14
+  retry?: Retry14
   role?: Role14
   pdl__context?: PdlContext14
   pdl__id?: PdlId14
@@ -3247,6 +3359,7 @@ export interface DataBlock {
   contribute?: Contribute13
   parser?: Parser13
   fallback?: Fallback13
+  retry?: Retry13
   role?: Role13
   pdl__context?: PdlContext13
   pdl__id?: PdlId13
@@ -3315,6 +3428,7 @@ export interface IfBlock {
   contribute?: Contribute12
   parser?: Parser12
   fallback?: Fallback12
+  retry?: Retry12
   role?: Role12
   pdl__context?: PdlContext12
   pdl__id?: PdlId12
@@ -3393,6 +3507,7 @@ export interface MatchBlock {
   contribute?: Contribute11
   parser?: Parser11
   fallback?: Fallback11
+  retry?: Retry11
   role?: Role11
   pdl__context?: PdlContext11
   pdl__id?: PdlId11
@@ -3461,6 +3576,7 @@ export interface RepeatBlock {
   contribute?: Contribute10
   parser?: Parser10
   fallback?: Fallback10
+  retry?: Retry10
   role?: Role10
   pdl__context?: PdlContext10
   pdl__id?: PdlId10
@@ -3525,6 +3641,7 @@ export interface TextBlock {
   contribute?: Contribute9
   parser?: Parser9
   fallback?: Fallback9
+  retry?: Retry9
   role?: Role9
   pdl__context?: PdlContext9
   pdl__id?: PdlId9
@@ -3583,6 +3700,7 @@ export interface LastOfBlock {
   contribute?: Contribute8
   parser?: Parser8
   fallback?: Fallback8
+  retry?: Retry8
   role?: Role8
   pdl__context?: PdlContext8
   pdl__id?: PdlId8
@@ -3641,6 +3759,7 @@ export interface ArrayBlock {
   contribute?: Contribute7
   parser?: Parser7
   fallback?: Fallback7
+  retry?: Retry7
   role?: Role7
   pdl__context?: PdlContext7
   pdl__id?: PdlId7
@@ -3699,6 +3818,7 @@ export interface ObjectBlock {
   contribute?: Contribute6
   parser?: Parser6
   fallback?: Fallback6
+  retry?: Retry6
   role?: Role6
   pdl__context?: PdlContext6
   pdl__id?: PdlId6
@@ -3757,6 +3877,7 @@ export interface MessageBlock {
   contribute?: Contribute5
   parser?: Parser5
   fallback?: Fallback5
+  retry?: Retry5
   role?: Role5
   pdl__context?: PdlContext5
   pdl__id?: PdlId5
@@ -3828,6 +3949,7 @@ export interface ReadBlock {
   contribute?: Contribute4
   parser?: Parser4
   fallback?: Fallback4
+  retry?: Retry4
   role?: Role4
   pdl__context?: PdlContext4
   pdl__id?: PdlId4
@@ -3887,6 +4009,7 @@ export interface IncludeBlock {
   contribute?: Contribute3
   parser?: Parser3
   fallback?: Fallback3
+  retry?: Retry3
   role?: Role3
   pdl__context?: PdlContext3
   pdl__id?: PdlId3
@@ -3946,6 +4069,7 @@ export interface ImportBlock {
   contribute?: Contribute2
   parser?: Parser2
   fallback?: Fallback2
+  retry?: Retry2
   role?: Role2
   pdl__context?: PdlContext2
   pdl__id?: PdlId2
@@ -4004,6 +4128,7 @@ export interface ErrorBlock {
   contribute?: Contribute1
   parser?: Parser1
   fallback?: Fallback1
+  retry?: Retry1
   role?: Role1
   pdl__context?: PdlContext1
   pdl__id?: PdlId1
@@ -4062,6 +4187,7 @@ export interface EmptyBlock {
   contribute?: Contribute
   parser?: Parser
   fallback?: Fallback
+  retry?: Retry
   role?: Role
   pdl__context?: PdlContext
   pdl__id?: PdlId

--- a/pdl-live-react/src/pdl_ast.d.ts
+++ b/pdl-live-react/src/pdl_ast.d.ts
@@ -265,6 +265,11 @@ export type Fallback =
  */
 export type Retry = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -348,6 +353,11 @@ export type Fallback1 =
  *
  */
 export type Retry1 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry1 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -464,6 +474,11 @@ export type Fallback2 =
  */
 export type Retry2 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry2 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -574,6 +589,11 @@ export type Fallback3 =
  *
  */
 export type Retry3 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry3 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -687,6 +707,11 @@ export type Fallback4 =
  */
 export type Retry4 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry4 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -781,6 +806,11 @@ export type Fallback5 =
  *
  */
 export type Retry5 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry5 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -898,6 +928,11 @@ export type Fallback6 =
  *
  */
 export type Retry6 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry6 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -1036,6 +1071,11 @@ export type Fallback7 =
  */
 export type Retry7 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry7 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1147,6 +1187,11 @@ export type Fallback8 =
  */
 export type Retry8 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry8 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1257,6 +1302,11 @@ export type Fallback9 =
  *
  */
 export type Retry9 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry9 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -1395,6 +1445,11 @@ export type Fallback10 =
  *
  */
 export type Retry10 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry10 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -1588,6 +1643,11 @@ export type Fallback11 =
  */
 export type Retry11 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry11 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1738,6 +1798,11 @@ export type Fallback12 =
  */
 export type Retry12 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry12 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1885,6 +1950,11 @@ export type Fallback13 =
  */
 export type Retry13 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry13 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -1969,6 +2039,11 @@ export type Fallback14 =
  */
 export type Retry14 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry14 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -2052,6 +2127,11 @@ export type Fallback15 =
  *
  */
 export type Retry15 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry15 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2138,6 +2218,11 @@ export type Fallback16 =
  *
  */
 export type Retry16 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry16 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2253,6 +2338,11 @@ export type Fallback17 =
  *
  */
 export type Retry17 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry17 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2406,6 +2496,11 @@ export type Fallback18 =
  *
  */
 export type Retry18 = number | null
+/**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry18 = boolean | string | null
 /**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
@@ -2596,6 +2691,11 @@ export type Fallback19 =
  */
 export type Retry19 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry19 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -2702,6 +2802,11 @@ export type Fallback20 =
  */
 export type Retry20 = number | null
 /**
+ * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+ *
+ */
+export type TraceErrorOnRetry20 = boolean | string | null
+/**
  * Role associated to the block and sub-blocks.
  * Typical roles are `system`, `user`, and `assistant`,
  * but there may be other roles such as `available_tools`.
@@ -2803,6 +2908,7 @@ export interface FunctionBlock {
   parser?: Parser20
   fallback?: Fallback20
   retry?: Retry20
+  trace_error_on_retry?: TraceErrorOnRetry20
   role?: Role20
   pdl__context?: PdlContext20
   pdl__id?: PdlId20
@@ -2939,6 +3045,7 @@ export interface CallBlock {
   parser?: Parser19
   fallback?: Fallback19
   retry?: Retry19
+  trace_error_on_retry?: TraceErrorOnRetry19
   role?: Role19
   pdl__context?: PdlContext19
   pdl__id?: PdlId19
@@ -3006,6 +3113,7 @@ export interface LitellmModelBlock {
   parser?: Parser18
   fallback?: Fallback18
   retry?: Retry18
+  trace_error_on_retry?: TraceErrorOnRetry18
   role?: Role18
   pdl__context?: PdlContext18
   pdl__id?: PdlId18
@@ -3074,6 +3182,7 @@ export interface GraniteioModelBlock {
   parser?: Parser17
   fallback?: Fallback17
   retry?: Retry17
+  trace_error_on_retry?: TraceErrorOnRetry17
   role?: Role17
   pdl__context?: PdlContext17
   pdl__id?: PdlId17
@@ -3153,6 +3262,7 @@ export interface CodeBlock {
   parser?: Parser16
   fallback?: Fallback16
   retry?: Retry16
+  trace_error_on_retry?: TraceErrorOnRetry16
   role?: Role16
   pdl__context?: PdlContext16
   pdl__id?: PdlId16
@@ -3220,6 +3330,7 @@ export interface ArgsBlock {
   parser?: Parser15
   fallback?: Fallback15
   retry?: Retry15
+  trace_error_on_retry?: TraceErrorOnRetry15
   role?: Role15
   pdl__context?: PdlContext15
   pdl__id?: PdlId15
@@ -3281,6 +3392,7 @@ export interface GetBlock {
   parser?: Parser14
   fallback?: Fallback14
   retry?: Retry14
+  trace_error_on_retry?: TraceErrorOnRetry14
   role?: Role14
   pdl__context?: PdlContext14
   pdl__id?: PdlId14
@@ -3360,6 +3472,7 @@ export interface DataBlock {
   parser?: Parser13
   fallback?: Fallback13
   retry?: Retry13
+  trace_error_on_retry?: TraceErrorOnRetry13
   role?: Role13
   pdl__context?: PdlContext13
   pdl__id?: PdlId13
@@ -3429,6 +3542,7 @@ export interface IfBlock {
   parser?: Parser12
   fallback?: Fallback12
   retry?: Retry12
+  trace_error_on_retry?: TraceErrorOnRetry12
   role?: Role12
   pdl__context?: PdlContext12
   pdl__id?: PdlId12
@@ -3508,6 +3622,7 @@ export interface MatchBlock {
   parser?: Parser11
   fallback?: Fallback11
   retry?: Retry11
+  trace_error_on_retry?: TraceErrorOnRetry11
   role?: Role11
   pdl__context?: PdlContext11
   pdl__id?: PdlId11
@@ -3577,6 +3692,7 @@ export interface RepeatBlock {
   parser?: Parser10
   fallback?: Fallback10
   retry?: Retry10
+  trace_error_on_retry?: TraceErrorOnRetry10
   role?: Role10
   pdl__context?: PdlContext10
   pdl__id?: PdlId10
@@ -3642,6 +3758,7 @@ export interface TextBlock {
   parser?: Parser9
   fallback?: Fallback9
   retry?: Retry9
+  trace_error_on_retry?: TraceErrorOnRetry9
   role?: Role9
   pdl__context?: PdlContext9
   pdl__id?: PdlId9
@@ -3701,6 +3818,7 @@ export interface LastOfBlock {
   parser?: Parser8
   fallback?: Fallback8
   retry?: Retry8
+  trace_error_on_retry?: TraceErrorOnRetry8
   role?: Role8
   pdl__context?: PdlContext8
   pdl__id?: PdlId8
@@ -3760,6 +3878,7 @@ export interface ArrayBlock {
   parser?: Parser7
   fallback?: Fallback7
   retry?: Retry7
+  trace_error_on_retry?: TraceErrorOnRetry7
   role?: Role7
   pdl__context?: PdlContext7
   pdl__id?: PdlId7
@@ -3819,6 +3938,7 @@ export interface ObjectBlock {
   parser?: Parser6
   fallback?: Fallback6
   retry?: Retry6
+  trace_error_on_retry?: TraceErrorOnRetry6
   role?: Role6
   pdl__context?: PdlContext6
   pdl__id?: PdlId6
@@ -3878,6 +3998,7 @@ export interface MessageBlock {
   parser?: Parser5
   fallback?: Fallback5
   retry?: Retry5
+  trace_error_on_retry?: TraceErrorOnRetry5
   role?: Role5
   pdl__context?: PdlContext5
   pdl__id?: PdlId5
@@ -3950,6 +4071,7 @@ export interface ReadBlock {
   parser?: Parser4
   fallback?: Fallback4
   retry?: Retry4
+  trace_error_on_retry?: TraceErrorOnRetry4
   role?: Role4
   pdl__context?: PdlContext4
   pdl__id?: PdlId4
@@ -4010,6 +4132,7 @@ export interface IncludeBlock {
   parser?: Parser3
   fallback?: Fallback3
   retry?: Retry3
+  trace_error_on_retry?: TraceErrorOnRetry3
   role?: Role3
   pdl__context?: PdlContext3
   pdl__id?: PdlId3
@@ -4070,6 +4193,7 @@ export interface ImportBlock {
   parser?: Parser2
   fallback?: Fallback2
   retry?: Retry2
+  trace_error_on_retry?: TraceErrorOnRetry2
   role?: Role2
   pdl__context?: PdlContext2
   pdl__id?: PdlId2
@@ -4129,6 +4253,7 @@ export interface ErrorBlock {
   parser?: Parser1
   fallback?: Fallback1
   retry?: Retry1
+  trace_error_on_retry?: TraceErrorOnRetry1
   role?: Role1
   pdl__context?: PdlContext1
   pdl__id?: PdlId1
@@ -4188,6 +4313,7 @@ export interface EmptyBlock {
   parser?: Parser
   fallback?: Fallback
   retry?: Retry
+  trace_error_on_retry?: TraceErrorOnRetry
   role?: Role
   pdl__context?: PdlContext
   pdl__id?: PdlId

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -4589,6 +4589,7 @@
               "type": "string"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             }
           ],
@@ -4617,6 +4618,7 @@
               "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7311,6 +7313,7 @@
               "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7539,6 +7542,7 @@
               "type": "string"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -318,7 +318,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -400,7 +399,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
               },
               {
                 "type": "string"
@@ -708,7 +707,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1225,7 +1223,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1299,7 +1296,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1312,7 +1309,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1705,7 +1702,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1894,7 +1890,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "items": {},
@@ -2204,7 +2200,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2278,7 +2273,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -2592,7 +2587,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2974,7 +2968,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3522,7 +3515,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3596,9 +3588,6 @@
         "function": {
           "anyOf": [
             {
-              "additionalProperties": {
-                "$ref": "#/$defs/PdlTypeType"
-              },
               "type": "object"
             },
             {
@@ -3991,7 +3980,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4365,7 +4353,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4439,7 +4426,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -4563,7 +4550,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4585,13 +4571,12 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             }
           ],
@@ -4601,7 +4586,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -4617,10 +4602,9 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -4933,7 +4917,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5011,7 +4994,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -5503,7 +5486,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5961,7 +5943,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6576,7 +6557,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7090,7 +7070,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7164,7 +7143,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -7287,7 +7266,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7312,10 +7290,9 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7466,7 +7443,6 @@
         "logit_bias": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7494,7 +7470,6 @@
         "response_format": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7544,7 +7519,6 @@
               "type": "string"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7602,7 +7576,6 @@
         "extra_headers": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7738,7 +7711,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression_TypeVar_": {
+    "LocalizedExpression__ExpressionTypeT_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -8063,7 +8036,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8141,7 +8113,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -8207,7 +8179,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -8639,7 +8611,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8797,7 +8768,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -8813,7 +8784,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -9149,7 +9120,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9666,7 +9636,7 @@
         "spec": {
           "anyOf": [
             {
-              "$ref": "#/$defs/PdlTypeType"
+              "type": "object"
             },
             {
               "type": "null"
@@ -10275,7 +10245,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10349,7 +10318,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -10406,7 +10375,7 @@
         "spec": {
           "anyOf": [
             {
-              "$ref": "#/$defs/PdlTypeType"
+              "type": "object"
             },
             {
               "type": "null"
@@ -10728,7 +10697,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10809,7 +10777,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
                   },
                   {
                     "items": {},
@@ -10833,7 +10801,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10933,7 +10901,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10949,7 +10917,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "integer"
@@ -11444,7 +11412,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -334,6 +334,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -415,7 +416,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
               },
               {
                 "type": "string"
@@ -739,6 +740,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1271,6 +1273,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1344,7 +1347,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1357,7 +1360,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1766,6 +1769,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1954,7 +1958,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "items": {},
@@ -2280,6 +2284,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2353,7 +2358,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -2683,6 +2688,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3080,6 +3086,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3643,6 +3650,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3716,9 +3724,7 @@
         "function": {
           "anyOf": [
             {
-              "additionalProperties": {
-                "$ref": "#/$defs/PdlTypeType"
-              },
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -4127,6 +4133,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4516,6 +4523,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4589,7 +4597,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4713,6 +4721,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4734,12 +4743,13 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             }
           ],
@@ -4749,7 +4759,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4765,9 +4775,10 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -5096,6 +5107,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5173,7 +5185,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -5681,6 +5693,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6154,6 +6167,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6784,6 +6798,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7313,6 +7328,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7386,7 +7402,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -7509,6 +7525,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7533,9 +7550,10 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7686,6 +7704,7 @@
         "logit_bias": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7713,6 +7732,7 @@
         "response_format": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7762,6 +7782,7 @@
               "type": "string"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7819,6 +7840,7 @@
         "extra_headers": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7954,7 +7976,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression__ExpressionTypeT_": {
+    "LocalizedExpression_TypeVar_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -8295,6 +8317,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8372,7 +8395,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -8438,7 +8461,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -8886,6 +8909,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9043,7 +9067,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -9059,7 +9083,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -9411,6 +9435,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9927,7 +9952,8 @@
         "spec": {
           "anyOf": [
             {
-              "$ref": "#/$defs/PdlTypeType"
+              "additionalProperties": true,
+              "type": "object"
             },
             {
               "type": "null"
@@ -10552,6 +10578,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10625,7 +10652,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -10682,7 +10709,8 @@
         "spec": {
           "anyOf": [
             {
-              "$ref": "#/$defs/PdlTypeType"
+              "additionalProperties": true,
+              "type": "object"
             },
             {
               "type": "null"
@@ -11020,6 +11048,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -11100,7 +11129,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -11124,7 +11153,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -11224,7 +11253,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -11240,7 +11269,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "integer"
@@ -11751,6 +11780,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -387,7 +387,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
               },
               {
                 "type": "string"
@@ -1260,7 +1260,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1273,7 +1273,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1842,7 +1842,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "items": {},
@@ -2213,7 +2213,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -4309,7 +4309,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -4455,7 +4455,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -4471,7 +4471,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -4487,7 +4487,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -4868,7 +4868,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -6969,7 +6969,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -7117,7 +7117,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -7543,7 +7543,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression_TypeVar_": {
+    "LocalizedExpression__ExpressionTypeT_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -7933,7 +7933,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -7999,7 +7999,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10102,7 +10102,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -10549,7 +10549,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
                   },
                   {
                     "items": {},
@@ -10573,7 +10573,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10673,7 +10673,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10689,7 +10689,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "integer"
@@ -10727,12 +10727,6 @@
           "description": "Define how to combine the result of each iteration.\n    ",
           "title": "Join"
         },
-        "retry_on_error": {
-          "default": false,
-          "description": "Indicate if this block should be retried when an error occurs.\n    ",
-          "title": "Retry On Error",
-          "type": "boolean"
-        },
         "retry_max": {
           "anyOf": [
             {
@@ -10743,6 +10737,7 @@
             }
           ],
           "default": 0,
+          "description": "Maximum number of retry on errors in the loop.\n    ",
           "title": "Retry Max"
         },
         "pdl__trace": {

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -301,6 +301,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -318,7 +334,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -400,7 +415,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
               },
               {
                 "type": "string"
@@ -691,6 +706,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -708,7 +739,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1208,6 +1238,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -1225,7 +1271,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1299,7 +1344,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1312,7 +1357,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1688,6 +1733,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -1705,7 +1766,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1894,7 +1954,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "items": {},
@@ -2187,6 +2247,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -2204,7 +2280,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2278,7 +2353,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -2575,6 +2650,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -2592,7 +2683,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2957,6 +3047,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -2974,7 +3080,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3505,6 +3610,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -3522,7 +3643,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3596,7 +3716,9 @@
         "function": {
           "anyOf": [
             {
-              "additionalProperties": true,
+              "additionalProperties": {
+                "$ref": "#/$defs/PdlTypeType"
+              },
               "type": "object"
             },
             {
@@ -3972,6 +4094,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -3989,7 +4127,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4346,6 +4483,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -4363,7 +4516,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4437,7 +4589,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -4561,7 +4713,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4583,13 +4734,12 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             }
           ],
@@ -4599,7 +4749,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -4615,10 +4765,9 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -4914,6 +5063,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -4931,7 +5096,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5009,7 +5173,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -5484,6 +5648,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -5501,7 +5681,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5942,6 +6121,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -5959,7 +6154,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6557,6 +6751,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -6574,7 +6784,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7071,6 +7280,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -7088,7 +7313,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7162,7 +7386,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -7285,7 +7509,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7310,10 +7533,9 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7464,7 +7686,6 @@
         "logit_bias": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7492,7 +7713,6 @@
         "response_format": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7542,7 +7762,6 @@
               "type": "string"
             },
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7600,7 +7819,6 @@
         "extra_headers": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7736,7 +7954,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression_TypeVar_": {
+    "LocalizedExpression__ExpressionTypeT_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -8044,6 +8262,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -8061,7 +8295,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8139,7 +8372,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -8205,7 +8438,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -8620,6 +8853,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -8637,7 +8886,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8795,7 +9043,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -8811,7 +9059,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -9130,6 +9378,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -9147,7 +9411,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9664,8 +9927,7 @@
         "spec": {
           "anyOf": [
             {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/$defs/PdlTypeType"
             },
             {
               "type": "null"
@@ -10257,6 +10519,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -10274,7 +10552,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10348,7 +10625,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -10405,8 +10682,7 @@
         "spec": {
           "anyOf": [
             {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/$defs/PdlTypeType"
             },
             {
               "type": "null"
@@ -10711,6 +10987,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -10728,7 +11020,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10809,7 +11100,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
                   },
                   {
                     "items": {},
@@ -10833,7 +11124,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10933,7 +11224,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -10949,7 +11240,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "integer"
@@ -11427,6 +11718,22 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
+        "trace_error_on_retry": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
+          "title": "Trace Error On Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -11444,7 +11751,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -7736,7 +7736,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression__ExpressionTypeT_": {
+    "LocalizedExpression_TypeVar_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -288,6 +288,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -664,6 +677,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -1169,6 +1195,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -1635,6 +1674,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -2122,6 +2174,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -2497,6 +2562,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -2865,6 +2943,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -3401,6 +3492,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -3857,6 +3961,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -4217,6 +4334,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -4772,6 +4902,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -5330,6 +5473,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -5774,6 +5930,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -6377,6 +6546,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -6877,6 +7059,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -7838,6 +8033,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -8401,6 +8609,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -8897,6 +9118,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [
@@ -10011,6 +10245,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -10451,6 +10698,19 @@
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
         },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
+        },
         "role": {
           "anyOf": [
             {
@@ -10726,19 +10986,6 @@
           },
           "description": "Define how to combine the result of each iteration.\n    ",
           "title": "Join"
-        },
-        "retry_max": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": 0,
-          "description": "Maximum number of retry on errors in the loop.\n    ",
-          "title": "Retry Max"
         },
         "pdl__trace": {
           "anyOf": [
@@ -11166,6 +11413,19 @@
           "default": null,
           "description": "Block to execute in case of error.\n    ",
           "title": "Fallback"
+        },
+        "retry": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "role": {
           "anyOf": [

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -416,7 +416,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
               },
               {
                 "type": "string"
@@ -1347,7 +1347,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1360,7 +1360,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1958,7 +1958,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "items": {},
@@ -2358,7 +2358,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -3724,7 +3724,9 @@
         "function": {
           "anyOf": [
             {
-              "additionalProperties": true,
+              "additionalProperties": {
+                "$ref": "#/$defs/PdlTypeType"
+              },
               "type": "object"
             },
             {
@@ -4597,7 +4599,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -4743,7 +4745,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -4759,7 +4761,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -4775,7 +4777,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -5185,7 +5187,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -7402,7 +7404,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -7550,7 +7552,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -7976,7 +7978,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression_TypeVar_": {
+    "LocalizedExpression__ExpressionTypeT_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -8395,7 +8397,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -8461,7 +8463,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -9067,7 +9069,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -9083,7 +9085,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -9952,8 +9954,7 @@
         "spec": {
           "anyOf": [
             {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/$defs/PdlTypeType"
             },
             {
               "type": "null"
@@ -10652,7 +10653,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -10709,8 +10710,7 @@
         "spec": {
           "anyOf": [
             {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/$defs/PdlTypeType"
             },
             {
               "type": "null"
@@ -11129,7 +11129,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
                   },
                   {
                     "items": {},
@@ -11153,7 +11153,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -11253,7 +11253,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -11269,7 +11269,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "integer"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -318,6 +318,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -399,7 +400,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
               },
               {
                 "type": "string"
@@ -707,6 +708,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1223,6 +1225,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1296,7 +1299,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1309,7 +1312,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1702,6 +1705,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1890,7 +1894,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "items": {},
@@ -2200,6 +2204,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2273,7 +2278,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -2587,6 +2592,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2968,6 +2974,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3515,6 +3522,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3588,6 +3596,7 @@
         "function": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -3980,6 +3989,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4353,6 +4363,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4426,7 +4437,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4550,6 +4561,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4571,7 +4583,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4586,7 +4598,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4602,7 +4614,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "object"
@@ -4917,6 +4929,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4994,7 +5007,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -5486,6 +5499,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5943,6 +5957,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6557,6 +6572,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7070,6 +7086,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7143,7 +7160,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -7266,6 +7283,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7290,7 +7308,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "object"
@@ -7443,6 +7461,7 @@
         "logit_bias": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7470,6 +7489,7 @@
         "response_format": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7576,6 +7596,7 @@
         "extra_headers": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -8036,6 +8057,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8113,7 +8135,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -8179,7 +8201,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -8611,6 +8633,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8768,7 +8791,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -8784,7 +8807,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -9120,6 +9143,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9636,6 +9660,7 @@
         "spec": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -10245,6 +10270,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10318,7 +10344,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -10375,6 +10401,7 @@
         "spec": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -10697,6 +10724,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10777,7 +10805,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -10801,7 +10829,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -10901,7 +10929,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -10917,7 +10945,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "integer"
@@ -11412,6 +11440,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -387,7 +387,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
               },
               {
                 "type": "string"
@@ -1260,7 +1260,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1273,7 +1273,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1842,7 +1842,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "items": {},
@@ -2213,7 +2213,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4309,7 +4309,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4455,7 +4455,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4471,7 +4471,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4487,7 +4487,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -4868,7 +4868,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -6969,7 +6969,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -7117,7 +7117,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -7543,7 +7543,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression__ExpressionTypeT_": {
+    "LocalizedExpression_TypeVar_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -7933,7 +7933,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -7999,7 +7999,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -10102,7 +10102,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -10549,7 +10549,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -10573,7 +10573,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -10673,7 +10673,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -10689,7 +10689,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "integer"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -416,7 +416,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
               },
               {
                 "type": "string"
@@ -1347,7 +1347,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1360,7 +1360,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1958,7 +1958,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "items": {},
@@ -2358,7 +2358,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4599,7 +4599,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4745,7 +4745,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4761,7 +4761,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4777,7 +4777,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -5187,7 +5187,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -7404,7 +7404,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -7552,7 +7552,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -7978,7 +7978,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression__ExpressionTypeT_": {
+    "LocalizedExpression_TypeVar_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -8397,7 +8397,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -8463,7 +8463,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -9069,7 +9069,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -9085,7 +9085,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -10653,7 +10653,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -11129,7 +11129,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -11153,7 +11153,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -11253,7 +11253,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -11269,7 +11269,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "integer"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -301,22 +301,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -334,6 +318,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -415,7 +400,7 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                "$ref": "#/$defs/LocalizedExpression_TypeVar_"
               },
               {
                 "type": "string"
@@ -706,22 +691,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -739,6 +708,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1238,22 +1208,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -1271,6 +1225,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1344,7 +1299,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1357,7 +1312,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1733,22 +1688,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -1766,6 +1705,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1954,7 +1894,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "items": {},
@@ -2247,22 +2187,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -2280,6 +2204,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -2353,7 +2278,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -2650,22 +2575,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -2683,6 +2592,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3047,22 +2957,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -3080,6 +2974,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3610,22 +3505,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -3643,6 +3522,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -3716,9 +3596,7 @@
         "function": {
           "anyOf": [
             {
-              "additionalProperties": {
-                "$ref": "#/$defs/PdlTypeType"
-              },
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -4094,22 +3972,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -4127,6 +3989,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4483,22 +4346,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -4516,6 +4363,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4589,7 +4437,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4713,6 +4561,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -4734,12 +4583,13 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             }
           ],
@@ -4749,7 +4599,7 @@
         "processor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -4765,9 +4615,10 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -5063,22 +4914,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -5096,6 +4931,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -5173,7 +5009,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -5648,22 +5484,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -5681,6 +5501,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6121,22 +5942,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -6154,6 +5959,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -6751,22 +6557,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -6784,6 +6574,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7280,22 +7071,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -7313,6 +7088,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7386,7 +7162,7 @@
         "model": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -7509,6 +7285,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -7533,9 +7310,10 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7686,6 +7464,7 @@
         "logit_bias": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7713,6 +7492,7 @@
         "response_format": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7762,6 +7542,7 @@
               "type": "string"
             },
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7819,6 +7600,7 @@
         "extra_headers": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -7954,7 +7736,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression__ExpressionTypeT_": {
+    "LocalizedExpression_TypeVar_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -8262,22 +8044,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -8295,6 +8061,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -8372,7 +8139,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -8438,7 +8205,7 @@
         "if": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -8853,22 +8620,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -8886,6 +8637,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9043,7 +8795,7 @@
         "name": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -9059,7 +8811,7 @@
         "tool_call_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -9378,22 +9130,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -9411,6 +9147,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -9927,7 +9664,8 @@
         "spec": {
           "anyOf": [
             {
-              "$ref": "#/$defs/PdlTypeType"
+              "additionalProperties": true,
+              "type": "object"
             },
             {
               "type": "null"
@@ -10519,22 +10257,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -10552,6 +10274,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -10625,7 +10348,7 @@
         "read": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -10682,7 +10405,8 @@
         "spec": {
           "anyOf": [
             {
-              "$ref": "#/$defs/PdlTypeType"
+              "additionalProperties": true,
+              "type": "object"
             },
             {
               "type": "null"
@@ -10987,22 +10711,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -11020,6 +10728,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -11100,7 +10809,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -11124,7 +10833,7 @@
         "while": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -11224,7 +10933,7 @@
         "until": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -11240,7 +10949,7 @@
         "max_iterations": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "integer"
@@ -11718,22 +11427,6 @@
           "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
           "title": "Retry"
         },
-        "trace_error_on_retry": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.\n    ",
-          "title": "Trace Error On Retry"
-        },
         "role": {
           "anyOf": [
             {
@@ -11751,6 +11444,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -10727,6 +10727,24 @@
           "description": "Define how to combine the result of each iteration.\n    ",
           "title": "Join"
         },
+        "retry_on_error": {
+          "default": false,
+          "description": "Indicate if this block should be retried when an error occurs.\n    ",
+          "title": "Retry On Error",
+          "type": "boolean"
+        },
+        "retry_max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0,
+          "title": "Retry Max"
+        },
         "pdl__trace": {
           "anyOf": [
             {

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -360,6 +360,9 @@ class Block(BaseModel):
     fallback: Optional["BlockType"] = None
     """Block to execute in case of error.
     """
+    retry: Optional[int] = None
+    """The maximum number of times to retry when an error occurs within a block.
+    """
     role: RoleType = None
     """Role associated to the block and sub-blocks.
     Typical roles are `system`, `user`, and `assistant`,
@@ -872,9 +875,6 @@ class RepeatBlock(StructuredBlock):
     """
     join: JoinType = JoinText()
     """Define how to combine the result of each iteration.
-    """
-    retry_max: Optional[int] = 0
-    """Maximum number of retry on errors in the loop.
     """
     # Field for internal use
     pdl__trace: Optional[list["BlockType"]] = None

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -873,11 +873,8 @@ class RepeatBlock(StructuredBlock):
     join: JoinType = JoinText()
     """Define how to combine the result of each iteration.
     """
-    retry_on_error: bool = False
-    """Indicate if this block should be retried when an error occurs.
-    """
-    retry_max: int = 3
-    """Maximum number of retry.
+    retry_max: Optional[int] = 0
+    """Maximum number of retry on errors in the loop.
     """
     # Field for internal use
     pdl__trace: Optional[list["BlockType"]] = None

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -363,6 +363,9 @@ class Block(BaseModel):
     retry: Optional[int] = None
     """The maximum number of times to retry when an error occurs within a block.
     """
+    trace_error_on_retry: Optional[bool] | str = None
+    """Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
+    """
     role: RoleType = None
     """Role associated to the block and sub-blocks.
     Typical roles are `system`, `user`, and `assistant`,

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -873,6 +873,12 @@ class RepeatBlock(StructuredBlock):
     join: JoinType = JoinText()
     """Define how to combine the result of each iteration.
     """
+    retry_on_error: bool = False
+    """Indicate if this block should be retried when an error occurs.
+    """
+    retry_max: int = 3
+    """Maximum number of retry.
+    """
     # Field for internal use
     pdl__trace: Optional[list["BlockType"]] = None
 

--- a/src/pdl/pdl_dumper.py
+++ b/src/pdl/pdl_dumper.py
@@ -234,8 +234,8 @@ def block_to_dict(  # noqa: C901
                     block.max_iterations, json_compatible
                 )
             d["join"] = join_to_dict(block.join)
-            if block.retry_max is not None:
-                d["retry_max"] = expr_to_dict(block.retry_max, json_compatible)
+            if block.retry is not None:
+                d["retry"] = expr_to_dict(block.retry, json_compatible)
             if block.pdl__trace is not None:
                 d["pdl__trace"] = [
                     block_to_dict(b, json_compatible) for b in block.pdl__trace

--- a/src/pdl/pdl_dumper.py
+++ b/src/pdl/pdl_dumper.py
@@ -126,6 +126,8 @@ def block_to_dict(  # noqa: C901
         }
     if block.retry is not None:
         d["retry"] = expr_to_dict(block.retry, json_compatible)
+    if block.trace_error_on_retry is not None:
+        d["trace_error_on_retry"] = expr_to_dict(block.trace_error_on_retry, json_compatible)
     if isinstance(block, StructuredBlock):
         d["context"] = block.context
 

--- a/src/pdl/pdl_dumper.py
+++ b/src/pdl/pdl_dumper.py
@@ -234,6 +234,8 @@ def block_to_dict(  # noqa: C901
                     block.max_iterations, json_compatible
                 )
             d["join"] = join_to_dict(block.join)
+            if block.retry_max is not None:
+                d["retry_max"] = expr_to_dict(block.retry_max, json_compatible)
             if block.pdl__trace is not None:
                 d["pdl__trace"] = [
                     block_to_dict(b, json_compatible) for b in block.pdl__trace

--- a/src/pdl/pdl_dumper.py
+++ b/src/pdl/pdl_dumper.py
@@ -124,6 +124,8 @@ def block_to_dict(  # noqa: C901
         d["defs"] = {
             x: block_to_dict(b, json_compatible) for x, b in block.defs.items()
         }
+    if block.retry is not None:
+        d["retry"] = expr_to_dict(block.retry, json_compatible)
     if isinstance(block, StructuredBlock):
         d["context"] = block.context
 
@@ -234,8 +236,6 @@ def block_to_dict(  # noqa: C901
                     block.max_iterations, json_compatible
                 )
             d["join"] = join_to_dict(block.join)
-            if block.retry is not None:
-                d["retry"] = expr_to_dict(block.retry, json_compatible)
             if block.pdl__trace is not None:
                 d["pdl__trace"] = [
                     block_to_dict(b, json_compatible) for b in block.pdl__trace

--- a/src/pdl/pdl_dumper.py
+++ b/src/pdl/pdl_dumper.py
@@ -127,7 +127,9 @@ def block_to_dict(  # noqa: C901
     if block.retry is not None:
         d["retry"] = expr_to_dict(block.retry, json_compatible)
     if block.trace_error_on_retry is not None:
-        d["trace_error_on_retry"] = expr_to_dict(block.trace_error_on_retry, json_compatible)
+        d["trace_error_on_retry"] = expr_to_dict(
+            block.trace_error_on_retry, json_compatible
+        )
     if isinstance(block, StructuredBlock):
         d["context"] = block.context
 

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -798,10 +798,10 @@ def process_block_body(
                 )
             repeat_loc = append(loc, "repeat")
             iidx = 0
-            first = True
-            saved_background: PdlLazy[list[dict[str, Any]]] = PdlList([])
-            while True:
-                try:
+            try:
+                first = True
+                saved_background: PdlLazy[list[dict[str, Any]]] = PdlList([])
+                while True:
                     if max_iterations is not None and iidx >= max_iterations:
                         break
                     if lengths is not None and iidx >= lengths[0]:

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -807,13 +807,24 @@ def process_block_body(
                         manual_stop = True
                     iter_trace.append(exc.pdl__trace)
                     trace = block.model_copy(update={"pdl__trace": iter_trace})
-                    if block.retry_on_error and retry_count < block.retry_max and not manual_stop:
+                    if (
+                        block.retry_max
+                        and block.retry_max > 0
+                        and retry_count < block.retry_max
+                        and not manual_stop
+                    ):
                         retry_count += 1
                         error = f"Retry on error is triggered in a repeat block. Error detail: {repr(exc)} "
                         print(f"\n\033[0;31m{error}\033[0m\n")
-                        if background and background.data and background.data[-1]["content"].endswith(error):
+                        if (
+                            background
+                            and background.data
+                            and background.data[-1]["content"].endswith(error)
+                        ):
                             error = "The previous error occurs multiple times."
-                        background = lazy_messages_concat(background, [{"role": "assistant", "content": error}])
+                        background = lazy_messages_concat(
+                            background, [{"role": "assistant", "content": error}]
+                        )
                     else:
                         raise PDLRuntimeError(
                             exc.message,

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -816,14 +816,19 @@ def process_block_body(
                         retry_count += 1
                         error = f"Retry on error is triggered in a repeat block. Error detail: {repr(exc)} "
                         print(f"\n\033[0;31m{error}\033[0m\n")
-                        if (
-                            background
-                            and background.data
-                            and background.data[-1]["content"].endswith(error)
-                        ):
+                        repeating_same_error = False
+                        if background and background.data:
+                            bg_data = background.data
+                            if isinstance(bg_data, list):
+                                last_error = bg_data[-1]["content"]
+                                if isinstance(last_error, str):
+                                    if last_error.endswith(error):
+                                        repeating_same_error = True
+                        if repeating_same_error:
                             error = "The previous error occurs multiple times."
                         background = lazy_messages_concat(
-                            background, [{"role": "assistant", "content": error}]
+                            background,
+                            PdlList([{"role": "assistant", "content": error}]),
                         )
                     else:
                         raise PDLRuntimeError(

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -439,8 +439,9 @@ def process_advanced_block(
                 raise exc from exc
             if do_retry:
                 error = f"An error occurred in a PDL block. Error details: {err_msg}"
-                print(f"\n\033[0;31m[Retry {trial_idx+1}/{max_retry}] {error}\033[0m\n")
-                scope = set_error_to_scope_for_retry(scope, error, block.pdl__id)
+                print(f"\n\033[0;31m[Retry {trial_idx+1}/{max_retry}] {error}\033[0m\n", file=sys.stderr)
+                if block.trace_error_on_retry:
+                    scope = set_error_to_scope_for_retry(scope, error, block.pdl__id)
                 continue
             (
                 result,

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -439,7 +439,10 @@ def process_advanced_block(
                 raise exc from exc
             if do_retry:
                 error = f"An error occurred in a PDL block. Error details: {err_msg}"
-                print(f"\n\033[0;31m[Retry {trial_idx+1}/{max_retry}] {error}\033[0m\n", file=sys.stderr)
+                print(
+                    f"\n\033[0;31m[Retry {trial_idx+1}/{max_retry}] {error}\033[0m\n",
+                    file=sys.stderr,
+                )
                 if block.trace_error_on_retry:
                     scope = set_error_to_scope_for_retry(scope, error, block.pdl__id)
                 continue

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,5 +1,5 @@
 import io
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 
 from pdl.pdl import exec_dict
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,6 +1,6 @@
 import io
 from contextlib import redirect_stdout
-import traceback
+
 from pdl.pdl import exec_dict
 
 
@@ -13,14 +13,17 @@ def repeat_retry_data(n: int):
                 {
                     "lang": "python",
                     "code": {
-                        "text": ["raise ValueError('dummy exception')\n", "result = 'World'"]
+                        "text": [
+                            "raise ValueError('dummy exception')\n",
+                            "result = 'World'",
+                        ]
                     },
                 },
                 "!\n",
             ],
-            "retry": n
+            "retry": n,
         },
-        "max_iterations": 2
+        "max_iterations": 2,
     }
 
 
@@ -67,11 +70,14 @@ def code_retry_data(n: int):
             {
                 "lang": "python",
                 "code": {
-                    "text": ["raise ValueError('dummy exception')\n", "result = 'hello, world!'"]
+                    "text": [
+                        "raise ValueError('dummy exception')\n",
+                        "result = 'hello, world!'",
+                    ]
                 },
             },
         ],
-        "retry": n
+        "retry": n,
     }
 
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,110 @@
+import io
+from contextlib import redirect_stdout
+import traceback
+from pdl.pdl import exec_dict
+
+
+def repeat_retry_data(n: int):
+    return {
+        "description": "Example of retry code within a repeat block",
+        "repeat": {
+            "text": [
+                "Hello, ",
+                {
+                    "lang": "python",
+                    "code": {
+                        "text": ["raise ValueError('dummy exception')\n", "result = 'World'"]
+                    },
+                },
+                "!\n",
+            ],
+            "retry": n
+        },
+        "max_iterations": 2
+    }
+
+
+def repeat_retry(n: int, should_be_no_error: bool = False):
+    err_msg = ""
+    # catch stdout string
+    with io.StringIO() as buf, redirect_stdout(buf):
+        try:
+            _ = exec_dict(repeat_retry_data(n))
+        except Exception:
+            pass
+        err_msg = buf.getvalue()
+
+    if should_be_no_error:
+        assert err_msg == ""
+    else:
+        assert f"[Retry 1/{n}]" in err_msg
+
+
+def test_repeat_retry_negative():
+    repeat_retry(-1, should_be_no_error=True)
+
+
+def test_repeat_retry0():
+    repeat_retry(0, should_be_no_error=True)
+
+
+def test_repeat_retry1():
+    repeat_retry(1)
+
+
+def test_repeat_retry2():
+    repeat_retry(2)
+
+
+def test_repeat_retry3():
+    repeat_retry(3)
+
+
+def code_retry_data(n: int):
+    return {
+        "description": "Example of retry code within a code block",
+        "text": [
+            {
+                "lang": "python",
+                "code": {
+                    "text": ["raise ValueError('dummy exception')\n", "result = 'hello, world!'"]
+                },
+            },
+        ],
+        "retry": n
+    }
+
+
+def code_retry(n: int, should_be_no_error: bool = False):
+    err_msg = ""
+    # catch stdout string
+    with io.StringIO() as buf, redirect_stdout(buf):
+        try:
+            _ = exec_dict(code_retry_data(n))
+        except Exception:
+            pass
+        err_msg = buf.getvalue()
+    if should_be_no_error:
+        assert err_msg == ""
+    else:
+        assert f"[Retry 1/{n}]" in err_msg
+
+
+def test_code_retry_negative():
+    code_retry(-1, should_be_no_error=True)
+
+
+def test_code_retry0():
+    code_retry(0, should_be_no_error=True)
+
+
+def test_code_retry1():
+    code_retry(1)
+
+
+def test_code_retry2():
+    code_retry(2)
+
+
+def test_code_retry3():
+    code_retry(3)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,5 +1,5 @@
 import io
-from contextlib import redirect_stdout
+from contextlib import redirect_stdout, redirect_stderr
 
 from pdl.pdl import exec_dict
 
@@ -30,7 +30,7 @@ def repeat_retry_data(n: int):
 def repeat_retry(n: int, should_be_no_error: bool = False):
     err_msg = ""
     # catch stdout string
-    with io.StringIO() as buf, redirect_stdout(buf):
+    with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
         try:
             _ = exec_dict(repeat_retry_data(n))
         except Exception:
@@ -84,7 +84,7 @@ def code_retry_data(n: int):
 def code_retry(n: int, should_be_no_error: bool = False):
     err_msg = ""
     # catch stdout string
-    with io.StringIO() as buf, redirect_stdout(buf):
+    with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
         try:
             _ = exec_dict(code_retry_data(n))
         except Exception:


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>


This PR is based on the issue https://github.com/IBM/prompt-declaration-language/issues/823 and it adds two new fields `retry` and `trace_error_on_retry` to the `block` class.
`retry` is an integer value which indicates the number of retry when some errors happen within the block. retry is enabled only when the value is specified and positive.
`trace_error_on_retry` is a boolean value whether to add error information to the trace. This defaults to None (=False), but when it is set to True, errors during retry are added to the trace. This is useful for multiple trials with `model` block to leverage self-reflection behavior of LLM.


```
The following is the original PR description before discussion in the comments.
---
This PR is based on the issue https://github.com/IBM/prompt-declaration-language/issues/823 and it adds two new fields `retry_on_error` and `retry_max` to the existing `repeat` block.
`retry_on_error` is a simple boolean value which indicates if the retry feature is enabled or not, and if true, errors while running the `repeat` block are added to the background context of the LLM.
`retry_max` is an integer value of the number of maximum retry.
This PR contains the following changes
- Update to the RepeatBlock model in `pdl_ast.py`
- Update while loop for repeat block in `pdl_interpreter.py`
- Update to the `schema.json`
```