### PR TITLE
fix: skip litellm 1.63.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "jinja2~=3.0",
   "PyYAML~=6.0",
   "jsonschema~=4.0",
-  "litellm>=1.57.3,!=1.59.9",
+  "litellm>=1.57.3,!=1.59.9,!=1.63.14",
   "termcolor~=2.0",
   "ipython>=8,<10",
   "json-repair~=0.35",


### PR DESCRIPTION
Error with examples/rag.py pre-commit run:
```
examples/rag/rag.py:108:21 - error: Cannot access attribute "data" for class "Coroutine[Any, Any, EmbeddingResponse]"
```

https://github.com/BerriAI/litellm/issues/9526