### PR TITLE
fix: pin openai==1.61.0 pip due to breaking change on their side

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "PyYAML~=6.0",
   "jsonschema~=4.0",
   "litellm>=1.57.3,!=1.59.9,!=1.63.14",
+  "openai==1.61.0",
   "termcolor~=2.0",
   "ipython>=8,<10",
   "json-repair~=0.35",


### PR DESCRIPTION
This is until we can pick up a litellm fix.

https://github.com/BerriAI/litellm/issues/9424