### PR TITLE
fix: avoid use of tauri `resources` to inject requirements.txt data

### DIFF
--- a/pdl-live-react/beeai-requirements.txt
+++ b/pdl-live-react/beeai-requirements.txt
@@ -1,2 +1,0 @@
--e git+https://github.com/starpit/bee-agent-framework.git@nick-meta-combo#egg=beeai_framework&subdirectory=python
-#beeai_framework==0.1

--- a/pdl-live-react/requirements.txt
+++ b/pdl-live-react/requirements.txt
@@ -1,2 +1,0 @@
-#-e ../
-prompt-declaration-language==0.5.1

--- a/pdl-live-react/src-tauri/src/cli/run.rs
+++ b/pdl-live-react/src-tauri/src/cli/run.rs
@@ -5,6 +5,7 @@ use yaml_rust2::yaml::LoadError;
 
 use crate::interpreter::pip::pip_install_internal_if_needed;
 use crate::interpreter::pull::pull_if_needed;
+use crate::interpreter::requirements::PDL_INTERPRETER;
 
 #[cfg(desktop)]
 pub fn run_pdl_program(
@@ -21,8 +22,7 @@ pub fn run_pdl_program(
 
     // async the model pull and pip installs
     let pull_future = pull_if_needed(&source_file_path);
-    let bin_path_future =
-        pip_install_internal_if_needed(app_handle, &"interpreter/requirements.txt");
+    let bin_path_future = pip_install_internal_if_needed(app_handle, &PDL_INTERPRETER);
 
     // wait for any model pulls to finish
     block_on(pull_future).map_err(|e| match e {

--- a/pdl-live-react/src-tauri/src/compile/beeai.rs
+++ b/pdl-live-react/src-tauri/src/compile/beeai.rs
@@ -13,6 +13,7 @@ use tempfile::Builder;
 
 use crate::interpreter::ast::{PdlBaseType, PdlBlock, PdlOptionalType, PdlParser, PdlType};
 use crate::interpreter::pip::pip_install_internal_if_needed;
+use crate::interpreter::requirements::BEEAI_FRAMEWORK;
 
 macro_rules! zip {
     ($x: expr) => ($x);
@@ -290,10 +291,7 @@ fn python_source_to_json(
     if *debug {
         eprintln!("Compiling from Python source");
     }
-    let bin_path = block_on(pip_install_internal_if_needed(
-        app_handle,
-        &"interpreter/beeai-requirements.txt",
-    ))?;
+    let bin_path = block_on(pip_install_internal_if_needed(app_handle, &BEEAI_FRAMEWORK))?;
 
     let dry_run_file_path = Builder::new()
         .prefix(&"pdl-bee")

--- a/pdl-live-react/src-tauri/src/interpreter/mod.rs
+++ b/pdl-live-react/src-tauri/src/interpreter/mod.rs
@@ -2,4 +2,5 @@ pub mod ast;
 pub mod extract;
 pub mod pip;
 pub mod pull;
+pub mod requirements;
 pub mod shasum;

--- a/pdl-live-react/src-tauri/src/interpreter/requirements.rs
+++ b/pdl-live-react/src-tauri/src/interpreter/requirements.rs
@@ -1,0 +1,5 @@
+//pub const pdl_interpreter = "-e ../";
+pub const PDL_INTERPRETER: &str = "prompt-declaration-language==0.5.1";
+
+pub const BEEAI_FRAMEWORK: &str = "-e git+https://github.com/starpit/bee-agent-framework.git@nick-meta-combo#egg=beeai_framework&subdirectory=python";
+//pub const beeai = "beeai_framework==0.1";

--- a/pdl-live-react/src-tauri/src/interpreter/shasum.rs
+++ b/pdl-live-react/src-tauri/src/interpreter/shasum.rs
@@ -1,11 +1,7 @@
-use ::std::fs::File;
-use ::std::io::{copy, Result};
-use ::std::path::Path;
-
 use base64ct::{Base64Url, Encoding};
 use sha2::{Digest, Sha256};
 
-pub fn sha256sum(path: &Path) -> Result<String> {
+/* pub fn sha256sum(path: &Path) -> Result<String> {
     let mut hasher = Sha256::new();
     let mut file = File::open(path)?;
 
@@ -13,4 +9,12 @@ pub fn sha256sum(path: &Path) -> Result<String> {
     let hash_bytes = hasher.finalize();
 
     Ok(Base64Url::encode_string(&hash_bytes))
+} */
+
+pub fn sha256sum_str(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s);
+    let hash_bytes = hasher.finalize();
+
+    Base64Url::encode_string(&hash_bytes)
 }

--- a/pdl-live-react/src-tauri/tauri.conf.json
+++ b/pdl-live-react/src-tauri/tauri.conf.json
@@ -87,10 +87,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": {
-      "../requirements.txt": "interpreter/requirements.txt",
-      "../beeai-requirements.txt": "interpreter/beeai-requirements.txt"
-    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
This is a step towards rendering the main logic agnostic of Tauri -- so that it can run in plain CLIs and other (non-tauri) applications.