### PR TITLE
fix: avoid use of tauri cache dir logic

### DIFF
--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -2682,6 +2682,7 @@ name = "pdl"
 version = "0.5.1"
 dependencies = [
  "base64ct",
+ "dirs",
  "duct",
  "futures",
  "rayon",

--- a/pdl-live-react/src-tauri/Cargo.toml
+++ b/pdl-live-react/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ yaml-rust2 = "0.10.0"
 futures = "0.3.31"
 sha2 = "0.10.8"
 base64ct = { version = "1.7.1", features = ["alloc"] }
+dirs = "6.0.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-cli = "2"

--- a/pdl-live-react/src-tauri/src/cli/run.rs
+++ b/pdl-live-react/src-tauri/src/cli/run.rs
@@ -3,14 +3,13 @@ use duct::cmd;
 use futures::executor::block_on;
 use yaml_rust2::yaml::LoadError;
 
-use crate::interpreter::pip::pip_install_internal_if_needed;
+use crate::interpreter::pip::pip_install_if_needed;
 use crate::interpreter::pull::pull_if_needed;
 use crate::interpreter::requirements::PDL_INTERPRETER;
 
 #[cfg(desktop)]
 pub fn run_pdl_program(
     source_file_path: String,
-    app_handle: tauri::AppHandle,
     trace_file: Option<&tauri_plugin_cli::ArgData>,
     data: Option<&tauri_plugin_cli::ArgData>,
     stream: Option<&tauri_plugin_cli::ArgData>,
@@ -22,7 +21,7 @@ pub fn run_pdl_program(
 
     // async the model pull and pip installs
     let pull_future = pull_if_needed(&source_file_path);
-    let bin_path_future = pip_install_internal_if_needed(app_handle, &PDL_INTERPRETER);
+    let bin_path_future = pip_install_if_needed(&PDL_INTERPRETER);
 
     // wait for any model pulls to finish
     block_on(pull_future).map_err(|e| match e {

--- a/pdl-live-react/src-tauri/src/cli/setup.rs
+++ b/pdl-live-react/src-tauri/src/cli/setup.rs
@@ -50,12 +50,7 @@ pub fn cli(app: &mut tauri::App) -> Result<(), Box<dyn ::std::error::Error>> {
                                 value: Value::Bool(debug),
                                 ..
                             }),
-                        ) => compile::beeai::compile(
-                            app.handle().clone(),
-                            source_file_path,
-                            output_file_path,
-                            debug,
-                        ),
+                        ) => compile::beeai::compile(source_file_path, output_file_path, debug),
                         _ => Err(Box::from("Invalid compile subcommand")),
                     }
                 }
@@ -68,7 +63,6 @@ pub fn cli(app: &mut tauri::App) -> Result<(), Box<dyn ::std::error::Error>> {
                 ..
             }) => run::run_pdl_program(
                 source_file_path.clone(),
-                app.handle().clone(),
                 subcommand_matches.matches.args.get("trace"),
                 subcommand_matches.matches.args.get("data"),
                 subcommand_matches.matches.args.get("stream"),

--- a/pdl-live-react/src-tauri/src/compile/beeai.rs
+++ b/pdl-live-react/src-tauri/src/compile/beeai.rs
@@ -12,7 +12,7 @@ use serde_json::{from_reader, json, to_string, Value};
 use tempfile::Builder;
 
 use crate::interpreter::ast::{PdlBaseType, PdlBlock, PdlOptionalType, PdlParser, PdlType};
-use crate::interpreter::pip::pip_install_internal_if_needed;
+use crate::interpreter::pip::pip_install_if_needed;
 use crate::interpreter::requirements::BEEAI_FRAMEWORK;
 
 macro_rules! zip {
@@ -284,14 +284,13 @@ fn tool_imports(object: &String) -> (&str, &str) {
 }
 
 fn python_source_to_json(
-    app_handle: tauri::AppHandle,
     source_file_path: &String,
     debug: &bool,
 ) -> Result<PathBuf, Box<dyn Error>> {
     if *debug {
         eprintln!("Compiling from Python source");
     }
-    let bin_path = block_on(pip_install_internal_if_needed(app_handle, &BEEAI_FRAMEWORK))?;
+    let bin_path = block_on(pip_install_if_needed(&BEEAI_FRAMEWORK))?;
 
     let dry_run_file_path = Builder::new()
         .prefix(&"pdl-bee")
@@ -317,7 +316,6 @@ fn python_source_to_json(
 }
 
 pub fn compile(
-    app_handle: tauri::AppHandle,
     source_file_path: &String,
     output_path: &String,
     debug: &bool,
@@ -331,7 +329,7 @@ pub fn compile(
         .and_then(OsStr::to_str)
     {
         Some("py") => {
-            let json_snapshot_file = python_source_to_json(app_handle, source_file_path, debug)?;
+            let json_snapshot_file = python_source_to_json(source_file_path, debug)?;
             File::open(json_snapshot_file)
         }
         _ => {

--- a/pdl-live-react/src-tauri/src/interpreter/pip.rs
+++ b/pdl-live-react/src-tauri/src/interpreter/pip.rs
@@ -1,16 +1,18 @@
 use ::std::fs::{create_dir_all, write};
-use ::std::path::{Path, PathBuf};
+use ::std::path::PathBuf;
 
+use dirs::cache_dir;
 use duct::cmd;
-use tauri::Manager;
 
 use crate::interpreter::shasum;
 
 #[cfg(desktop)]
-async fn pip_install_if_needed(
-    cache_path: &Path,
+pub async fn pip_install_if_needed(
     requirements: &str,
 ) -> Result<PathBuf, Box<dyn ::std::error::Error>> {
+    let Some(cache_path) = cache_dir() else {
+        return Err(Box::from("Could not find user cache directory"));
+    };
     create_dir_all(&cache_path)?;
 
     let hash = shasum::sha256sum_str(requirements);
@@ -37,13 +39,4 @@ async fn pip_install_if_needed(
     }
 
     Ok(bin_path.to_path_buf())
-}
-
-#[cfg(desktop)]
-pub async fn pip_install_internal_if_needed(
-    app_handle: tauri::AppHandle,
-    requirements: &str,
-) -> Result<PathBuf, Box<dyn ::std::error::Error>> {
-    let cache_path = app_handle.path().cache_dir()?.join("pdl");
-    pip_install_if_needed(&cache_path, requirements).await
 }


### PR DESCRIPTION
We can use the `dirs` crate. This is a step towards rendering the main logic agnostic of Tauri -- so that it can run in plain CLIs and other (non-tauri) applications.