### PR TITLE
fix: rust pull logic may not always pull

### DIFF
--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -1377,6 +1377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.0.5",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,6 +3377,7 @@ dependencies = [
  "base64ct",
  "dirs",
  "duct",
+ "fs4",
  "futures",
  "indexmap 2.9.0",
  "minijinja",

--- a/pdl-live-react/src-tauri/Cargo.toml
+++ b/pdl-live-react/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { version = "1.44.1", features = ["io-std"] }
 indexmap = { version = "2.9.0", features = ["serde"] }
 rustpython-stdlib = { version = "0.4.0", features = ["zlib"] }
 schemars = "0.8.22"
+fs4 = "0.13.1"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-cli = "2"

--- a/pdl-live-react/src-tauri/src/pdl/extract.rs
+++ b/pdl-live-react/src-tauri/src/pdl/extract.rs
@@ -31,24 +31,43 @@ fn extract_values_iter(program: &PdlBlock, field: &str, values: &mut Vec<String>
             .array
             .iter()
             .for_each(|p| extract_values_iter(p, field, values)),
-        PdlBlock::Text(b) => b
-            .text
-            .iter()
-            .for_each(|p| extract_values_iter(p, field, values)),
-        PdlBlock::LastOf(b) => b
-            .last_of
-            .iter()
-            .for_each(|p| extract_values_iter(p, field, values)),
+        PdlBlock::Text(b) => {
+            b.text
+                .iter()
+                .for_each(|p| extract_values_iter(p, field, values));
+            if let Some(defs) = &b.defs {
+                defs.values()
+                    .for_each(|p| extract_values_iter(p, field, values));
+            }
+        }
+        PdlBlock::LastOf(b) => {
+            b.last_of
+                .iter()
+                .for_each(|p| extract_values_iter(p, field, values));
+            if let Some(defs) = &b.defs {
+                defs.values()
+                    .for_each(|p| extract_values_iter(p, field, values));
+            }
+        }
         PdlBlock::If(b) => {
             extract_values_iter(&b.then, field, values);
             if let Some(else_) = &b.else_ {
                 extract_values_iter(else_, field, values);
+            }
+            if let Some(defs) = &b.defs {
+                defs.values()
+                    .for_each(|p| extract_values_iter(p, field, values));
             }
         }
         PdlBlock::Object(b) => b
             .object
             .values()
             .for_each(|p| extract_values_iter(p, field, values)),
+
+        PdlBlock::Function(b) => {
+            extract_values_iter(&b.return_, field, values);
+        }
+
         _ => {}
     }
 }


### PR DESCRIPTION
1. extract was not traversing completely, thus missing some model references 
2. ollama pull itself (the CLI) may double/triple fetch if concurrent ollama pulls are launched. this PR introduces a file lock to avoid this. in github actions, we were running out of disk space due to this issue.