### PR TITLE
fix: improve support for rust interpreter python imports from venv

### DIFF
--- a/.github/workflows/rust-interpreter.yml
+++ b/.github/workflows/rust-interpreter.yml
@@ -31,4 +31,8 @@ jobs:
             (curl -fsSL https://ollama.com/install.sh | sudo -E sh && sleep 2)
           wait
       - name: Run interpreter tests
-        run: npm run test:interpreter
+        run: |
+          python3.12 -mvenv venv
+          source venv/bin/activate
+          pip install nested-diff
+          npm run test:interpreter

--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -2987,7 +2987,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4243,6 +4243,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "once_cell",
+ "parking_lot",
  "radium",
  "rustpython-literal",
  "rustpython-wtf8",

--- a/pdl-live-react/src-tauri/Cargo.toml
+++ b/pdl-live-react/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ minijinja = { version = "2.9.0", features = ["custom_syntax"] }
 #ollama-rs = { version = "0.3.0", features = ["stream"] }
 ollama-rs = { git = "https://github.com/starpit/ollama-rs.git", branch = "tools-pub-7", features = ["stream"] }
 owo-colors = "4.2.0"
-rustpython-vm = { git="https://github.com/RustPython/RustPython.git" } # "0.4.0"
+rustpython-vm = { git="https://github.com/RustPython/RustPython.git", features= ["importlib", "threading", "encodings"] } # "0.4.0"
 async-recursion = "1.1.1"
 tokio-stream = "0.1.17"
 tokio = { version = "1.44.1", features = ["io-std"] }

--- a/pdl-live-react/src-tauri/src/pdl/interpreter_tests.rs
+++ b/pdl-live-react/src-tauri/src/pdl/interpreter_tests.rs
@@ -319,6 +319,45 @@ mod tests {
     }
 
     #[test]
+    fn text_python_two_code_result_dict() -> Result<(), Box<dyn Error>> {
+        let program = json!({
+            "text": [
+                { "lang": "python",
+                   "code":"print('hi ho'); result = {\"foo\": 3}"
+                },
+                { "lang": "python",
+                   "code":"import os; print('hi ho'); result = {\"foo\": 4}"
+                }
+            ]
+        });
+
+        let (_, messages, _) = run_json(program, streaming(), initial_scope())?;
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, MessageRole::User);
+        assert_eq!(messages[0].content, "{'foo': 3}");
+        assert_eq!(messages[1].role, MessageRole::User);
+        assert_eq!(messages[1].content, "{'foo': 4}");
+        Ok(())
+    }
+
+    // TODO: illegal instruction, but only during tests
+    #[test]
+    fn text_python_code_import_venv() -> Result<(), Box<dyn Error>> {
+        let program = json!({
+            "include": "./tests/cli/code-python.pdl"
+        });
+
+        let (_, messages, _) = run_json(program, streaming(), initial_scope())?;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, MessageRole::User);
+        assert_eq!(
+            messages[0].content,
+            "{'foo': None, 'diff': {'D': {'two': {'N': 3}}}}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn text_read_file_text() -> Result<(), Box<dyn Error>> {
         let program = json!({
             "message": "Read a file",

--- a/pdl-live-react/src-tauri/tests/cli/code-python.pdl
+++ b/pdl-live-react/src-tauri/tests/cli/code-python.pdl
@@ -1,5 +1,10 @@
 lang: python
 code: |
-  import os
-  print(f"hi ho {os.getcwd()}")
-  result = {"foo": 3}
+  import sys # test import stdlib
+  import os # test import stdlib
+  print(f"!!! {sys.path}")
+  #import textdistance # test import from venv
+  from nested_diff import diff # test import from venv
+  a = {'one': 1, 'two': 2, 'three': 3}
+  b = {'one': 1, 'two': 3, 'three': 3}
+  result = {"foo": os.getenv("FOO999999999999999999999999"), "diff": diff(a, b, O=False, U=False)}


### PR DESCRIPTION
a bit of a hack at the moment to find (on linux/mac) the site-packages subdir when running in a virtual env. it should work on python 3.12. otherwise, one needs to set `PYTHONPATH` or `PDLPYTHONPATH`.