### PR TITLE
fix: unable to set OPENAI_API_BASE for litellm

### DIFF
--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -1,6 +1,7 @@
 """PDL programs are represented by the Pydantic data structure defined in this file."""
 
 from enum import StrEnum
+from os import environ
 from typing import (
     Annotated,
     Any,
@@ -449,7 +450,7 @@ class LitellmParameters(BaseModel):
     """The name of the function to call within the conversation (default is an empty string)
     """
     # set api_base, api_version, api_key
-    base_url: Optional[str] | str = None
+    base_url: Optional[str] | str = environ.get("OPENAI_BASE_URL")
     """Base URL for the API (default is None).
     """
     api_version: Optional[str] | str = None


### PR DESCRIPTION
This is helpful when communicating with a non-standard endpoint, e.g. one running locally. for local execution, it would normally be `OPENAI_API_BASE=http://localhost:8000/v1`