### PR TITLE
feat: change the semantics of function calls to put the returned value in `pdl_context`

### DIFF
--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -230,7 +230,7 @@ lastOf:
 """
     result = exec_str(prog)
     assert result == [
-        "Bye[{'role': 'user', 'content': 'Hello', 'pdl__defsite': 'lastOf.0'},{'role': 'user', 'content': 'How are you?', 'pdl__defsite': 'lastOf.1.array.0.text.0.call.lastOf.0'},{'role': 'user', 'content': 'Bye', 'pdl__defsite': 'lastOf.1.array.0.text.0.call.lastOf.1'}]",
+        "Bye[{'role': 'user', 'content': 'Hello', 'pdl__defsite': 'lastOf.0'},{'role': 'user', 'content': 'Bye', 'pdl__defsite': 'lastOf.1.array.0.text.0.call'}]",
         "Bye[{'role': 'user', 'content': 'Hello', 'pdl__defsite': 'lastOf.0'},{'role': 'user', 'content': 'Bye', 'pdl__defsite': 'lastOf.1.array.1.text.0'}]",
         "Bye[{'role': 'user', 'content': 'Hello', 'pdl__defsite': 'lastOf.0'},{'role': 'user', 'content': 'Bye', 'pdl__defsite': 'lastOf.1.array.2.text.0.code'}]",
     ]


### PR DESCRIPTION
With this PR, the background context of the body of a function stays local to the function and only the result of the function is added to the context when it is called.

For example, in the following program:

```
defs:
  f:
    function:
    return:
      lastOf:
      - How are you?
      - Bye
lastOf:
- Hello
- call: ${f}
- ${pdl_context}
```

The output is 
```
[ {'role': 'user', 'content': 'Hello'},
  {'role': 'user', 'content': 'Bye'} ]
```

Warning: inlining  a function might change the background context.