### PR TITLE
feat: the scope of the `content` field is local

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -783,7 +783,7 @@ def process_block_body(
             if state.yield_result and not iteration_state.yield_result:
                 yield_result(result, block.kind)
         case MessageBlock():
-            content, _, scope, trace = process_block_of(
+            content, _, _, trace = process_block_of(
                 block,
                 "content",
                 state,

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -147,3 +147,48 @@ array:
             "pdl__defsite": "array.0.message",
         }
     ]
+
+
+def test_messages6():
+    prog_str = """
+description: Message block scope
+defs:
+    x: 1
+array:
+  - content:
+        defs:
+            x: 2
+        text: ${ x }
+  - content:
+        text: ${ x }
+"""
+    result = exec_str(prog_str, output="all")
+    context = result["scope"]["pdl_context"]
+    assert [m.serialize(SerializeMode.LITELLM) for m in result["result"]] == [
+        [
+            {
+                "role": "user",
+                "content": "2",
+                "pdl__defsite": "array.0.message",
+            }
+        ],
+        [
+            {
+                "role": "user",
+                "content": "1",
+                "pdl__defsite": "array.1.message",
+            }
+        ],
+    ]
+    assert context.serialize(SerializeMode.LITELLM) == [
+        {
+            "role": "user",
+            "content": "2",
+            "pdl__defsite": "array.0.message",
+        },
+        {
+            "role": "user",
+            "content": "1",
+            "pdl__defsite": "array.1.message",
+        },
+    ]


### PR DESCRIPTION
Change the scoping role in the message blocks. The scope of the `content` field is now local. So the following example is now raising an error:

```
lastOf:
- content:
   defs:
      x: 1
   text: Hello
- ${x}
```