### PR TITLE
Prevent AggregatorBlock from being cached in replay

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -638,7 +638,9 @@ def process_block_body_with_replay(
     assert state.id_stack is not None
     block_id = ".".join(state.id_stack)
     block.pdl__id = block_id
-    if isinstance(block, LeafBlock) and not isinstance(block, CallBlock):
+    if isinstance(block, LeafBlock) and not isinstance(
+        block, (CallBlock, AggregatorBlock)
+    ):
         assert isinstance(block_id, str)
         if block_id not in state.replay:
             result, background, scope, trace = process_block_body(


### PR DESCRIPTION
Change the semantics`AggregatorBlock` in replay mode. These blocks are not cached anymore and thus re-executed.

**Changes:**
- Updated `process_block_body_with_replay()` to exclude `AggregatorBlock` from replay caching, similar to `CallBlock`
- Changed line 641-643 in `src/pdl/pdl_interpreter.py` to use tuple-based exclusion: `not isinstance(block, (CallBlock, AggregatorBlock))`

This ensures aggregator blocks always execute fresh, preventing incorrect behavior when using aggregators in the contribute field.