### PR TITLE
Fix: Add FunctionBlock to replay check in process_block_body_with_replay

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -641,7 +641,7 @@ def process_block_body_with_replay(
     block_id = ".".join(state.id_stack)
     block.pdl__id = block_id
     if isinstance(block, LeafBlock) and not isinstance(
-        block, (CallBlock, AggregatorBlock)
+        block, (FunctionBlock, CallBlock, AggregatorBlock)
     ):
         assert isinstance(block_id, str)
         if block_id not in state.replay:


### PR DESCRIPTION
# Summary

Add `FunctionBlock` to the block type exclusion list in the replay processing logic. This ensures that `FunctionBlock` instances are handled consistently with `CallBlock` and `AggregatorBlock` during block body replay processing.

# Files Changed

📄 `src/pdl/pdl_interpreter.py`

Updated the `process_block_body_with_replay` function to exclude `FunctionBlock` from the conditional check that processes `LeafBlock` instances. Previously, only `CallBlock` and `AggregatorBlock` were excluded from this replay logic; now `FunctionBlock` is also excluded, treating it as a special block type that doesn't require the standard replay processing applied to other leaf blocks.