### PR TITLE
Add seaborn dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "json-repair~=0.35",
   "granite-io>=0.5,<0.6",
   "matplotlib~=3.10",
+  "seaborn~=0.13",
 ]
 authors = [
   { name="Mandana Vaziri", email="mvaziri@us.ibm.com" },


### PR DESCRIPTION
## Summary
This PR adds `seaborn~=0.13` as a project dependency in `pyproject.toml`.

## Changes
- Added `seaborn~=0.13` to the dependencies list in `pyproject.toml`

## Motivation
Seaborn is a statistical data visualization library built on matplotlib that provides a high-level interface for drawing attractive and informative statistical graphics.