### PR TITLE
Security: Arbitrary File Read via read_trace Tauri Command

### DIFF
--- a/pdl-live-react/src-tauri/src/commands/read_trace.rs
+++ b/pdl-live-react/src-tauri/src/commands/read_trace.rs
@@ -1,8 +1,20 @@
 use std::fs::read;
+use std::path::Path;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 pub fn read_trace(trace_file: &str) -> Result<Vec<u8>, String> {
-    let data = read(trace_file).map_err(|e| e.to_string())?;
+    let path = Path::new(trace_file);
+    let allowed_ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    if allowed_ext != "json" && allowed_ext != "pdl" {
+        return Err("Invalid file extension. Only .json and .pdl are allowed.".to_string());
+    }
+    let canonical = path.canonicalize().map_err(|e| e.to_string())?;
+    let current_dir = std::env::current_dir().map_err(|e| e.to_string())?;
+    let current_dir = current_dir.canonicalize().map_err(|e| e.to_string())?;
+    if !canonical.starts_with(&current_dir) {
+        return Err("Path is outside of allowed directory.".to_string());
+    }
+    let data = read(&canonical).map_err(|e| e.to_string())?;
     Ok(data)
 }


### PR DESCRIPTION
## Summary

Security: Arbitrary File Read via read_trace Tauri Command

## Problem

**Severity**: `High` | **File**: `pdl-live-react/src-tauri/src/commands/read_trace.rs:L1`

The `read_trace` Tauri command in `read_trace.rs` accepts a file path string and directly reads it using `std::fs::read`. There is no path validation, sanitization, or restriction to prevent reading files outside of intended directories. This allows an attacker to read arbitrary files on the system by passing paths like `../../../etc/passwd` or `C:\Windows\System32\config\SAM`. Since this is exposed as a Tauri command, it can be invoked from the frontend JavaScript.

## Solution

Validate and restrict the file path to a specific allowed directory. Use `std::path::Path::canonicalize` and ensure the resolved path is within an allowed base directory. Consider using a whitelist or sandbox approach. Also validate that the file extension is `.json` or `.pdl` as expected.

## Changes

- `pdl-live-react/src-tauri/src/commands/read_trace.rs` (modified)