### PR TITLE
fix(ci): cache Ollama models from their real storage location

### DIFF
--- a/.github/actions/ollama/action.yml
+++ b/.github/actions/ollama/action.yml
@@ -9,11 +9,18 @@ runs:
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-    # Cache Ollama models
+    # Cache Ollama models.
+    # The install script below runs Ollama as the `ollama` system user, which by
+    # default stores models under /usr/share/ollama/.ollama/models. That path is
+    # outside $HOME and cannot be restored by actions/cache (the runner user has
+    # no write access to /usr/share), so the cache was always empty and the models
+    # were re-downloaded on every run. We redirect the models directory to
+    # ~/.ollama/models (see the "Configure Ollama models directory" step) and cache
+    # that instead.
     - name: Cache Ollama models
       uses: actions/cache@v5
       with:
-        path: ~/.ollama
+        path: ~/.ollama/models
         key: ollama-models-${{ runner.os }}-${{ hashFiles('.github/actions/ollama/action.yml') }}
         restore-keys: |
           ollama-models-${{ runner.os }}-
@@ -23,6 +30,26 @@ runs:
       shell: bash
       run: |
         curl -fsSL https://ollama.com/install.sh | sudo -E sh
+
+    - name: Configure Ollama models directory
+      shell: bash
+      run: |
+        # Point the Ollama service at the cached ~/.ollama/models directory so that
+        # pulled models persist across runs. The directory may already be populated
+        # by the cache restore above; make sure it exists and is owned by the
+        # `ollama` service user so the server can read cached models and write new
+        # ones. The default umask keeps the files world-readable so the post-job
+        # cache save (which runs as the runner user) can read them back out.
+        sudo mkdir -p "$HOME/.ollama/models"
+        sudo chown -R ollama:ollama "$HOME/.ollama"
+        sudo chmod -R a+rX "$HOME/.ollama"
+        sudo mkdir -p /etc/systemd/system/ollama.service.d
+        cat <<EOF | sudo tee /etc/systemd/system/ollama.service.d/override.conf
+        [Service]
+        Environment="OLLAMA_MODELS=$HOME/.ollama/models"
+        EOF
+        sudo systemctl daemon-reload
+        sudo systemctl restart ollama
 
     - name: Wait for Ollama server
       shell: bash

--- a/.github/actions/ollama/action.yml
+++ b/.github/actions/ollama/action.yml
@@ -72,8 +72,9 @@ runs:
           fi
           attempt=$((attempt + 1))
         done
-        
+
         echo "❌ Failed to connect to Ollama server after $max_attempts attempts"
+        exit 1
 
     - name: Pull models in examples/
       shell: bash


### PR DESCRIPTION
The run-examples workflow cached `~/.ollama`, but the Ollama install script runs the server as the `ollama` system user, which stores models under /usr/share/ollama/.ollama/models. That path is outside $HOME and cannot be restored by actions/cache, so the cache was always empty and the models were re-downloaded on every run.

Redirect the Ollama service's models directory to ~/.ollama/models via a systemd drop-in override and cache that path instead, so pulled models persist across runs.
