### PR TITLE
Run test_dump, test_dump_exclude_internals, and test_valid_programs file loops in parallel

### DIFF
--- a/tests/test_ast_utils.py
+++ b/tests/test_ast_utils.py
@@ -1,4 +1,5 @@
 import pathlib
+from concurrent.futures import ThreadPoolExecutor
 
 from pdl.pdl_ast_utils import MappedFunctions, iter_block_children, map_block_children
 from pdl.pdl_parser import PDLParseError, parse_file
@@ -36,14 +37,20 @@ class MapCounter:
         return ast
 
 
+def _check_ast_iterators(yaml_file_name: pathlib.Path) -> None:
+    try:
+        ast, _ = parse_file(yaml_file_name)
+        iter_cpt = IterCounter()
+        iter_cpt.count(ast.root)
+        map_cpt = MapCounter()
+        map_cpt.count(ast.root)
+        assert iter_cpt.cpt == map_cpt.cpt, yaml_file_name
+    except PDLParseError:
+        pass
+
+
 def test_ast_iterators() -> None:
-    for yaml_file_name in pathlib.Path(".").glob("**/*.pdl"):
-        try:
-            ast, _ = parse_file(yaml_file_name)
-            iter_cpt = IterCounter()
-            iter_cpt.count(ast.root)
-            map_cpt = MapCounter()
-            map_cpt.count(ast.root)
-            assert iter_cpt.cpt == map_cpt.cpt, yaml_file_name
-        except PDLParseError:
+    with ThreadPoolExecutor() as executor:
+        # Consume the iterator so any exception raised in a worker propagates.
+        for _ in executor.map(_check_ast_iterators, pathlib.Path(".").glob("**/*.pdl")):
             pass

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,4 +1,5 @@
 import pathlib
+from concurrent.futures import ThreadPoolExecutor
 
 from pdl.pdl_ast import BlockType, IncludeBlock
 from pdl.pdl_ast_utils import iter_block_children
@@ -20,22 +21,55 @@ def has_include(block: BlockType) -> bool:
     return b
 
 
+def _check_dump(yaml_file_name: pathlib.Path) -> None:
+    try:
+        ast1, _ = parse_file(yaml_file_name)
+        if has_include(ast1.root):
+            return
+        d = program_to_dict(ast1)
+        s = dump_yaml(d)
+        ast2, _ = parse_str(s)
+        json1 = ast1.model_dump_json()
+        json2 = ast2.model_dump_json()
+        assert json1 == json2, f"{yaml_file_name}:\n{s}"
+    except PDLParseError:
+        pass
+    except Exception as exc:
+        assert False, f"{yaml_file_name}: {repr(exc)}"
+
+
 def test_dump() -> None:
-    for yaml_file_name in pathlib.Path(".").glob("**/*.pdl"):
-        try:
-            ast1, _ = parse_file(yaml_file_name)
-            if has_include(ast1.root):
-                continue
-            d = program_to_dict(ast1)
-            s = dump_yaml(d)
-            ast2, _ = parse_str(s)
-            json1 = ast1.model_dump_json()
-            json2 = ast2.model_dump_json()
-            assert json1 == json2, f"{yaml_file_name}:\n{s}"
-        except PDLParseError:
-            pass
-        except Exception as exc:
-            assert False, f"{yaml_file_name}: {repr(exc)}"
+    with ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(_check_dump, yaml_file_name)
+            for yaml_file_name in pathlib.Path(".").glob("**/*.pdl")
+        ]
+        for future in futures:
+            future.result()
+
+
+def _check_dump_exclude_internals(
+    yaml_file_name: pathlib.Path, known_internals: set[str]
+) -> None:
+    try:
+        ast1, _ = parse_file(yaml_file_name)
+        if has_include(ast1.root):
+            return
+        d = program_to_dict(ast1)
+        s = dump_yaml(d)
+        assert all(
+            field in s for field in known_internals
+        ), f"Internal fields not found in dump: {s}"
+
+        ast2, _ = parse_file(yaml_file_name)
+        s = dump_program_exclude_internals(ast2)
+        assert all(
+            field not in s for field in known_internals
+        ), "Internal fields found in dump"
+    except PDLParseError:
+        pass
+    except Exception as exc:
+        assert False, f"{yaml_file_name}: {repr(exc)}"
 
 
 def test_dump_exclude_internals() -> None:
@@ -49,23 +83,12 @@ def test_dump_exclude_internals() -> None:
         "pdl__is_leaf",
     }
 
-    for yaml_file_name in pathlib.Path(".").glob("**/*.pdl"):
-        try:
-            ast1, _ = parse_file(yaml_file_name)
-            if has_include(ast1.root):
-                continue
-            d = program_to_dict(ast1)
-            s = dump_yaml(d)
-            assert all(
-                field in s for field in known_internals
-            ), f"Internal fields not found in dump: {s}"
-
-            ast2, _ = parse_file(yaml_file_name)
-            s = dump_program_exclude_internals(ast2)
-            assert all(
-                field not in s for field in known_internals
-            ), "Internal fields found in dump"
-        except PDLParseError:
-            pass
-        except Exception as exc:
-            assert False, f"{yaml_file_name}: {repr(exc)}"
+    with ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(
+                _check_dump_exclude_internals, yaml_file_name, known_internals
+            )
+            for yaml_file_name in pathlib.Path(".").glob("**/*.pdl")
+        ]
+        for future in futures:
+            future.result()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,5 +1,6 @@
 import pathlib
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 
 from pdl.pdl_ast import BlockType, IncludeBlock
 from pdl.pdl_ast_utils import iter_block_children
@@ -40,12 +41,9 @@ def _check_dump(yaml_file_name: pathlib.Path) -> None:
 
 def test_dump() -> None:
     with ThreadPoolExecutor() as executor:
-        futures = [
-            executor.submit(_check_dump, yaml_file_name)
-            for yaml_file_name in pathlib.Path(".").glob("**/*.pdl")
-        ]
-        for future in futures:
-            future.result()
+        # Consume the iterator so any exception raised in a worker propagates.
+        for _ in executor.map(_check_dump, pathlib.Path(".").glob("**/*.pdl")):
+            pass
 
 
 def _check_dump_exclude_internals(
@@ -83,12 +81,8 @@ def test_dump_exclude_internals() -> None:
         "pdl__is_leaf",
     }
 
+    check = partial(_check_dump_exclude_internals, known_internals=known_internals)
     with ThreadPoolExecutor() as executor:
-        futures = [
-            executor.submit(
-                _check_dump_exclude_internals, yaml_file_name, known_internals
-            )
-            for yaml_file_name in pathlib.Path(".").glob("**/*.pdl")
-        ]
-        for future in futures:
-            future.result()
+        # Consume the iterator so any exception raised in a worker propagates.
+        for _ in executor.map(check, pathlib.Path(".").glob("**/*.pdl")):
+            pass

--- a/tests/test_examples_parse.py
+++ b/tests/test_examples_parse.py
@@ -1,4 +1,5 @@
 import pathlib
+from concurrent.futures import ThreadPoolExecutor
 
 from pytest import CaptureFixture
 
@@ -16,20 +17,28 @@ EXPECTED_INVALID = [
 ]
 
 
+def _parse_program(yaml_file_name: pathlib.Path) -> str | None:
+    """Parse a program, returning its name if it is invalid, None otherwise."""
+    try:
+        _ = parse_file(yaml_file_name)
+        return None
+    except PDLParseError:
+        return str(yaml_file_name)
+
+
 def test_valid_programs(capsys: CaptureFixture[str]) -> None:
-    actual_invalid: set[str] = set()
-    with_warnings: set[str] = set()
-    for yaml_file_name in pathlib.Path(".").glob("**/*.pdl"):
-        try:
-            _ = parse_file(yaml_file_name)
-            captured = capsys.readouterr()
-            if len(captured.err) > 0:
-                with_warnings |= {str(yaml_file_name)}
-        except PDLParseError:
-            actual_invalid |= {str(yaml_file_name)}
+    with ThreadPoolExecutor() as executor:
+        results = executor.map(
+            _parse_program, pathlib.Path(".").glob("**/*.pdl")
+        )
+        actual_invalid: set[str] = {name for name in results if name is not None}
+    # stderr is captured process-wide, so warnings cannot be attributed to
+    # individual files when parsing runs in parallel; check the aggregate.
+    captured = capsys.readouterr()
+    with_warnings = captured.err
     expected_invalid = set(str(p) for p in EXPECTED_INVALID)
     unexpected_invalid = sorted(list(actual_invalid - expected_invalid))
     assert len(unexpected_invalid) == 0, unexpected_invalid
     unexpected_valid = sorted(list(expected_invalid - actual_invalid))
     assert len(unexpected_valid) == 0, unexpected_valid
-    assert len(with_warnings) == 0
+    assert len(with_warnings) == 0, with_warnings

--- a/tests/test_examples_parse.py
+++ b/tests/test_examples_parse.py
@@ -28,9 +28,7 @@ def _parse_program(yaml_file_name: pathlib.Path) -> str | None:
 
 def test_valid_programs(capsys: CaptureFixture[str]) -> None:
     with ThreadPoolExecutor() as executor:
-        results = executor.map(
-            _parse_program, pathlib.Path(".").glob("**/*.pdl")
-        )
+        results = executor.map(_parse_program, pathlib.Path(".").glob("**/*.pdl"))
         actual_invalid: set[str] = {name for name in results if name is not None}
     # stderr is captured process-wide, so warnings cannot be attributed to
     # individual files when parsing runs in parallel; check the aggregate.


### PR DESCRIPTION
Refactor the per-file loop bodies into helper functions and dispatch them across a ThreadPoolExecutor so each .pdl file is processed concurrently. Exceptions are re-raised in the main thread via future.result() so failures still surface.

For test_valid_programs, stderr is captured process-wide by capsys, so warnings can no longer be attributed to individual files; the warning check now reads capsys once after all parses complete.
