### PR TITLE
fix(linter): return a real Program from parse mocks in test_linter

### DIFF
--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -21,7 +21,7 @@ from pdl.pdl_linter import (
     _setup_logging,
     run_linter,
 )
-from pdl.pdl_parser import PDLParseError
+from pdl.pdl_parser import PDLParseError, parse_str
 
 INVALID_PDL_FILE = Path("invalid.pdl")
 VALID_PDL_FILE = Path("valid.pdl")
@@ -84,7 +84,9 @@ def mock_parse_side_effect(file_path):
     if file_path == INVALID_PDL_FILE or file_path.name == INVALID_PDL_FILE.name:
         raise PDLParseError("Mocked parse error for invalid file")
     if file_path == VALID_PDL_FILE or file_path.name == VALID_PDL_FILE.name:
-        return (None, None)  # Simulate successful parse
+        # Simulate a successful parse by returning a real (Program, location)
+        # tuple so the linter can inspect the program (e.g. its code blocks).
+        return parse_str("text: Hello!")
     # Should not happen in this test if paths are correct
     raise FileNotFoundError(f"Unexpected file path in mock: {file_path}")
 
@@ -697,7 +699,7 @@ def test_run_linter_multiple_paths(
     def mock_parse_multi(file_path):
         if file_path == Path("invalid3.pdl"):
             raise PDLParseError("error")
-        return (None, None)
+        return parse_str("text: Hello!")
 
     with ChangeDir(project_root):
 


### PR DESCRIPTION
The linter's `_lint_pdl_file` now calls `_lint_python_code_blocks(prog.root)` (from the "check Python syntax in the linter" feature), which dereferences the Program returned by `parse_pdl_file`. The test mocks still returned `(None, None)` for a successful parse, so `prog.root` raised `AttributeError: 'NoneType' object has no attribute 'root'`. That was swallowed by the broad `except Exception` and reported valid files as lint failures, breaking `test_lint_pdl_file_valid` and `test_lint_pdl_files_in_directory`.

`parse_file`/`parse_str` never return `None` for the program on success (they raise `PDLParseError` on failure), so the mocks were simply out of date. Return a real parsed program instead so the linter exercises its actual code path.


Claude-Session: https://claude.ai/code/session_01HwKT9Rh69oqLgXhe5UBrgV