### PR TITLE
fix: make retry exception filtering actually filter

### DIFF
--- a/pdl-live-react/src/pdl_ast.d.ts
+++ b/pdl-live-react/src/pdl_ast.d.ts
@@ -117,14 +117,19 @@ export type ContributeTarget = "result" | "context" | "stdout" | "stderr"
  */
 export type Contribute = ContributeElement[]
 export type ParserType =
-  | ("json" | "jsonl" | "yaml" | "csv")
-  | PdlParser
-  | RegexParser
+  ("json" | "jsonl" | "yaml" | "csv") | PdlParser | RegexParser
 export type Regex = string
 export type Mode = "search" | "match" | "fullmatch" | "split" | "findall"
-export type Feedback = LocalizedExpression | FunctionBlock | string | null
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry = OptionalInt | RetryConfiguration
+export type OptionalInt = number | null
 export type Path = string[]
 export type File = string
+export type ExpressionFloat = LocalizedExpression | number | string
+export type Feedback = LocalizedExpression | FunctionBlock | string | null
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -146,6 +151,11 @@ export type Call = LocalizedExpression | FunctionBlock | string
  */
 export type Contribute1 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry1 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -157,6 +167,11 @@ export type Kind1 = "model"
  *
  */
 export type Contribute2 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry2 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -170,6 +185,11 @@ export type Kind2 = "model"
  */
 export type Contribute3 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry3 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -181,6 +201,11 @@ export type Kind3 = "model"
  *
  */
 export type Contribute4 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry4 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -194,6 +219,11 @@ export type Kind4 = "code"
  */
 export type Contribute5 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry5 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -205,6 +235,11 @@ export type Kind5 = "code"
  *
  */
 export type Contribute6 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry6 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -218,6 +253,11 @@ export type Kind6 = "code"
  */
 export type Contribute7 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry7 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -230,6 +270,11 @@ export type Kind7 = "code"
  */
 export type Contribute8 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry8 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -241,6 +286,11 @@ export type Kind8 = "code"
  *
  */
 export type Contribute9 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry9 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -261,6 +311,11 @@ export type Args1 = ExpressionStr[]
  */
 export type Contribute10 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry10 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -276,6 +331,11 @@ export type Get = string
  *
  */
 export type Contribute11 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry11 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -293,6 +353,11 @@ export type Raw = boolean
  */
 export type Contribute12 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry12 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -304,6 +369,11 @@ export type Kind12 = "message"
  *
  */
 export type Contribute13 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry13 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -321,6 +391,11 @@ export type Multiline = boolean
  *
  */
 export type Contribute14 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry14 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -343,6 +418,11 @@ export type Resample = boolean
  *
  */
 export type Contribute15 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry15 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -389,6 +469,11 @@ export type Flush = LocalizedExpression | boolean | string
  */
 export type Contribute16 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry16 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -406,6 +491,11 @@ export type Msg = string
  */
 export type Contribute17 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry17 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -417,6 +507,11 @@ export type Kind17 = "empty"
  *
  */
 export type Contribute18 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry18 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -471,6 +566,11 @@ export type Reduce = LocalizedExpression | string
  */
 export type Contribute19 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry19 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -495,6 +595,11 @@ export type Text = BlockType | BlockType[]
  */
 export type Contribute20 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry20 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -518,6 +623,11 @@ export type Lastof = BlockType[]
  */
 export type Contribute21 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry21 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -540,6 +650,11 @@ export type Array = BlockType[]
  *
  */
 export type Contribute22 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry22 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -568,6 +683,11 @@ export type Object1 =
  */
 export type Contribute23 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry23 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -586,6 +706,11 @@ export type Kind23 = "if"
  *
  */
 export type Contribute24 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry24 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -624,6 +749,11 @@ export type With1 = MatchCase[]
  */
 export type Contribute25 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry25 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -649,6 +779,11 @@ export type For = {
  *
  */
 export type Contribute26 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry26 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -676,6 +811,11 @@ export type For1 = {
  */
 export type Contribute27 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry27 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -699,6 +839,11 @@ export type Include = string
  *
  */
 export type Contribute28 = ContributeElement[]
+/**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry28 = OptionalInt | RetryConfiguration
 /**
  * Specify any expectations that the result of the block must satisfy.
  *
@@ -862,6 +1007,11 @@ export type MaxRetries = number | string | null
  */
 export type Contribute29 = ContributeElement[]
 /**
+ * The maximum number of times to retry when an error occurs within a block.
+ *
+ */
+export type Retry29 = OptionalInt | RetryConfiguration
+/**
  * Specify any expectations that the result of the block must satisfy.
  *
  */
@@ -973,11 +1123,7 @@ export interface FunctionBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry29
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -1135,11 +1281,7 @@ export interface CallBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -1251,11 +1393,15 @@ export interface RegexParser {
   mode?: Mode
 }
 /**
- * Single expectation definition.
+ * Configuration of the `retry` field.
  */
-export interface ExpectationType {
-  expect: unknown
-  feedback?: Feedback
+export interface RetryConfiguration {
+  tries?: LocalizedExpression | number | string
+  exceptions?: unknown
+  delay?: LocalizedExpression | number | string
+  max_delay?: ExpressionFloat | null
+  backoff?: LocalizedExpression | number | string
+  jitter?: LocalizedExpression | number | [unknown, unknown] | string
 }
 export interface LocalizedExpression {
   pdl__expr: PdlExpr
@@ -1275,6 +1421,13 @@ export interface PdlLocationType {
 }
 export interface Table {
   [k: string]: number
+}
+/**
+ * Single expectation definition.
+ */
+export interface ExpectationType {
+  expect: unknown
+  feedback?: Feedback
 }
 /**
  * Internal data structure to record timing information in the trace.
@@ -1346,11 +1499,7 @@ export interface LitellmModelBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry1
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -1500,11 +1649,7 @@ export interface GraniteioModelBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry2
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -1655,11 +1800,7 @@ export interface OpenaiModelBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry3
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -1818,11 +1959,7 @@ export interface PythonCodeBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry4
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -1963,11 +2100,7 @@ export interface IPythonCodeBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry5
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2109,11 +2242,7 @@ export interface JinjaCodeBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry6
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2263,11 +2392,7 @@ export interface PdlCodeBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry7
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2407,11 +2532,7 @@ export interface CommandCodeBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry8
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2552,11 +2673,7 @@ export interface ArgsBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry9
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2651,11 +2768,7 @@ export interface GetBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry10
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2768,11 +2881,7 @@ export interface DataBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry11
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -2865,11 +2974,7 @@ export interface MessageBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry12
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3019,11 +3124,7 @@ export interface ReadBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry13
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3125,11 +3226,7 @@ export interface FactorBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry14
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3223,11 +3320,7 @@ export interface AggregatorBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry15
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3328,11 +3421,7 @@ export interface ErrorBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry16
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3460,11 +3549,7 @@ export interface EmptyBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry17
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3555,11 +3640,7 @@ export interface SequenceBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry18
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3689,11 +3770,7 @@ export interface TextBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry19
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3786,11 +3863,7 @@ export interface LastOfBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry20
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3883,11 +3956,7 @@ export interface ArrayBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry21
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -3980,11 +4049,7 @@ export interface ObjectBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry22
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -4087,11 +4152,7 @@ export interface IfBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry23
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -4246,11 +4307,7 @@ export interface MatchBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry24
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -4409,11 +4466,7 @@ export interface RepeatBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry25
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -4589,11 +4642,7 @@ export interface MapBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry26
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -4743,11 +4792,7 @@ export interface IncludeBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry27
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *
@@ -4841,11 +4886,7 @@ export interface ImportBlock {
    *
    */
   fallback?: BlockType | null
-  /**
-   * The maximum number of times to retry when an error occurs within a block.
-   *
-   */
-  retry?: number | null
+  retry?: Retry28
   /**
    * Whether to add the errors while retrying to the trace. Set this to true to use retry feature for multiple LLM trials.
    *

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -51,9 +51,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -197,9 +205,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -324,9 +340,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -568,9 +592,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -626,7 +658,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "$ref": "#/$defs/FunctionBlock"
@@ -641,7 +673,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -714,9 +746,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -826,7 +866,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -893,9 +933,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -951,7 +999,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1025,9 +1073,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -1151,9 +1207,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -1230,7 +1294,7 @@
         "expect": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -1242,7 +1306,7 @@
         "feedback": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "$ref": "#/$defs/FunctionBlock"
@@ -1292,7 +1356,7 @@
     "ExpressionBool": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
         },
         {
           "type": "boolean"
@@ -1305,7 +1369,7 @@
     "ExpressionDictStr": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
         },
         {
           "additionalProperties": true,
@@ -1316,10 +1380,49 @@
         }
       ]
     },
+    "ExpressionFloat": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ExpressionFloatOrFloatFloat": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "type": "array"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "ExpressionInt": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
         },
         {
           "type": "integer"
@@ -1332,7 +1435,7 @@
     "ExpressionList": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
         },
         {
           "items": {},
@@ -1346,7 +1449,7 @@
     "ExpressionStr": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
         },
         {
           "type": "string"
@@ -1404,9 +1507,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -1462,7 +1573,7 @@
         "factor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "number"
@@ -1510,7 +1621,7 @@
         "file": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -1522,7 +1633,7 @@
         "mode": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -1535,7 +1646,7 @@
         "encoding": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -1551,7 +1662,7 @@
         "prefix": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -1564,7 +1675,7 @@
         "suffix": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -1577,7 +1688,7 @@
         "flush": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "boolean"
@@ -1648,9 +1759,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -1796,9 +1915,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -1914,9 +2041,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -2005,7 +2140,7 @@
               "$ref": "#/$defs/GraniteioProcessor"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -2018,7 +2153,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -2055,7 +2190,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -2126,9 +2261,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -2255,9 +2398,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -2386,9 +2537,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -2512,9 +2671,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -2647,9 +2814,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -2794,7 +2969,7 @@
         "reduce": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "type": "string"
@@ -2926,9 +3101,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -3051,9 +3234,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -3146,7 +3337,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -3577,7 +3768,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression_TypeVar_": {
+    "LocalizedExpression__ExpressionTypeT_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -3655,9 +3846,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -3720,7 +3919,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
                   },
                   {
                     "items": {},
@@ -3841,9 +4040,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -3903,7 +4110,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {},
             {
@@ -4021,9 +4228,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -4160,9 +4375,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -4335,9 +4558,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -4430,7 +4661,7 @@
               "$ref": "#/$defs/OpenaiParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
             },
             {
               "additionalProperties": true,
@@ -4558,6 +4789,16 @@
       "anyOf": [
         {
           "$ref": "#/$defs/ExpressionDictStr"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "OptionalExpressionFloat": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExpressionFloat"
         },
         {
           "type": "null"
@@ -4816,9 +5057,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -5098,9 +5347,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -5227,9 +5484,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -5390,9 +5655,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -5455,7 +5728,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
+                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
                   },
                   {
                     "items": {},
@@ -5530,6 +5803,58 @@
       "title": "RepeatBlock",
       "type": "object"
     },
+    "RetryConfiguration": {
+      "additionalProperties": false,
+      "description": "Configuration of the `retry` field.",
+      "properties": {
+        "tries": {
+          "$ref": "#/$defs/ExpressionInt",
+          "default": -1
+        },
+        "exceptions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+            },
+            {
+              "type": "string"
+            },
+            {},
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {}
+                ]
+              },
+              "type": "array"
+            }
+          ],
+          "default": "Exception",
+          "title": "Exceptions"
+        },
+        "delay": {
+          "$ref": "#/$defs/ExpressionFloat",
+          "default": 0.0
+        },
+        "max_delay": {
+          "$ref": "#/$defs/OptionalExpressionFloat",
+          "default": null
+        },
+        "backoff": {
+          "$ref": "#/$defs/ExpressionFloat",
+          "default": 1.0
+        },
+        "jitter": {
+          "$ref": "#/$defs/ExpressionFloatOrFloatFloat",
+          "default": 0.0
+        }
+      },
+      "title": "RetryConfiguration",
+      "type": "object"
+    },
     "SequenceBlock": {
       "additionalProperties": false,
       "description": "Generalization of the `text`, `lastOf`, `array`, and `object` blocks combining a list of blocks with a `join` operator.",
@@ -5581,9 +5906,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",
@@ -5711,9 +6044,17 @@
           "description": "Block to execute in case of error.\n    "
         },
         "retry": {
-          "$ref": "#/$defs/OptionalInt",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OptionalInt"
+            },
+            {
+              "$ref": "#/$defs/RetryConfiguration"
+            }
+          ],
           "default": null,
-          "description": "The maximum number of times to retry when an error occurs within a block.\n    "
+          "description": "The maximum number of times to retry when an error occurs within a block.\n    ",
+          "title": "Retry"
         },
         "trace_error_on_retry": {
           "$ref": "#/$defs/OptionalBoolOrStr",

--- a/src/pdl/pdl-schema.json
+++ b/src/pdl/pdl-schema.json
@@ -658,7 +658,7 @@
         "call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "$ref": "#/$defs/FunctionBlock"
@@ -673,7 +673,7 @@
         "args": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -866,7 +866,7 @@
         "value": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -999,7 +999,7 @@
         "data": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1294,7 +1294,7 @@
         "expect": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -1306,7 +1306,7 @@
         "feedback": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "$ref": "#/$defs/FunctionBlock"
@@ -1356,7 +1356,7 @@
     "ExpressionBool": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "type": "boolean"
@@ -1369,7 +1369,7 @@
     "ExpressionDictStr": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "additionalProperties": true,
@@ -1383,7 +1383,7 @@
     "ExpressionFloat": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "type": "number"
@@ -1396,7 +1396,7 @@
     "ExpressionFloatOrFloatFloat": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "type": "number"
@@ -1422,7 +1422,7 @@
     "ExpressionInt": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "type": "integer"
@@ -1435,7 +1435,7 @@
     "ExpressionList": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "items": {},
@@ -1449,7 +1449,7 @@
     "ExpressionStr": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+          "$ref": "#/$defs/LocalizedExpression_TypeVar_"
         },
         {
           "type": "string"
@@ -1573,7 +1573,7 @@
         "factor": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "number"
@@ -1621,7 +1621,7 @@
         "file": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -1633,7 +1633,7 @@
         "mode": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -1646,7 +1646,7 @@
         "encoding": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -1662,7 +1662,7 @@
         "prefix": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -1675,7 +1675,7 @@
         "suffix": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -1688,7 +1688,7 @@
         "flush": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "boolean"
@@ -2140,7 +2140,7 @@
               "$ref": "#/$defs/GraniteioProcessor"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -2153,7 +2153,7 @@
         "parameters": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -2190,7 +2190,7 @@
         "backend": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -2969,7 +2969,7 @@
         "reduce": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"
@@ -3337,7 +3337,7 @@
               "$ref": "#/$defs/LitellmParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -3768,7 +3768,7 @@
       "title": "LitellmParameters",
       "type": "object"
     },
-    "LocalizedExpression__ExpressionTypeT_": {
+    "LocalizedExpression_TypeVar_": {
       "additionalProperties": false,
       "properties": {
         "pdl__expr": {
@@ -3919,7 +3919,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -4110,7 +4110,7 @@
         "match": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {},
             {
@@ -4661,7 +4661,7 @@
               "$ref": "#/$defs/OpenaiParameters"
             },
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "additionalProperties": true,
@@ -5728,7 +5728,7 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+                    "$ref": "#/$defs/LocalizedExpression_TypeVar_"
                   },
                   {
                     "items": {},
@@ -5814,7 +5814,7 @@
         "exceptions": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalizedExpression__ExpressionTypeT_"
+              "$ref": "#/$defs/LocalizedExpression_TypeVar_"
             },
             {
               "type": "string"

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -388,10 +388,11 @@ class RetryConfiguration(BaseModel):
     """The maximum number of attempts. default: -1 (infinite).
     """
 
-    exceptions: ExpressionType[str | Type[Exception] | list[Type[Exception]]] = (
+    exceptions: ExpressionType[str | Type[Exception] | list[str | Type[Exception]]] = (
         "Exception"
     )
     """An exception or a list of exceptions to catch.
+    Exceptions can be given either as Python exception classes or as their names.
     """
 
     delay: ExpressionFloat = 0.0
@@ -1502,12 +1503,17 @@ class PDLRuntimeProcessBlocksError(PDLException):
         blocks: list[BlockType],
         loc: PdlLocationType | None = None,
         fallback: OptionalAny = None,
+        source_exception: BaseException | None = None,
     ):
         super().__init__(message)
         self.loc = loc
         self.blocks = blocks
         self.fallback = fallback
         self.message = message
+        if source_exception is not None:
+            if hasattr(source_exception, "source_exception"):
+                source_exception = source_exception.source_exception  # pyright: ignore
+        self.source_exception = source_exception
 
 
 # Default model parameter constants

--- a/src/pdl/pdl_ast.py
+++ b/src/pdl/pdl_ast.py
@@ -1469,7 +1469,7 @@ class PDLException(Exception):
 
 
 class PDLRuntimeError(PDLException):
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         message: str,
         loc: PdlLocationType | None = None,
@@ -1497,7 +1497,7 @@ class PDLRuntimeParserError(PDLRuntimeError):
 
 
 class PDLRuntimeProcessBlocksError(PDLException):
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         message: str,
         blocks: list[BlockType],

--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -1,4 +1,5 @@
 # pylint: disable=import-outside-toplevel
+import builtins
 import csv
 import json
 import random
@@ -45,6 +46,7 @@ from jinja2.runtime import Undefined
 from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 
+from . import pdl_ast
 from .pdl_ast import (
     AdvancedBlockType,
     AggregatorBlock,
@@ -526,6 +528,68 @@ def calculate_retry_delay(
     return float(delay)
 
 
+def resolve_exception_types(
+    exceptions: Any,
+    loc: PdlLocationType,
+) -> tuple[type[BaseException], ...]:
+    """Resolve the `exceptions` field of a retry configuration into exception classes.
+
+    Each exception can be given either as a Python exception class or as the
+    name of a builtin exception or of a PDL exception.
+
+    Args:
+        exceptions: A single exception or a list of exceptions.
+        loc: Location of the retry configuration, used to report errors.
+
+    Returns:
+        The exception classes to catch, as a tuple suitable for `isinstance`.
+    """
+    if isinstance(exceptions, (list, tuple)):
+        exception_list = list(exceptions)
+    else:
+        exception_list = [exceptions]
+
+    resolved: list[type[BaseException]] = []
+    for exception in exception_list:
+        if isinstance(exception, str):
+            candidate = getattr(builtins, exception, None)
+            if candidate is None:
+                candidate = getattr(pdl_ast, exception, None)
+        else:
+            candidate = exception
+        if not (isinstance(candidate, type) and issubclass(candidate, BaseException)):
+            raise PDLRuntimeError(
+                f"Invalid exception in the retry configuration: {exception!r}",
+                loc=loc,
+            )
+        resolved.append(candidate)
+    return tuple(resolved)
+
+
+def exception_matches(
+    exc: BaseException,
+    exception_types: tuple[type[BaseException], ...],
+) -> bool:
+    """Check whether an exception, or any exception it wraps, matches `exception_types`.
+
+    PDL wraps the exceptions raised by a program into `PDLRuntimeError`s as they
+    propagate, so the exception the user wrote in the retry configuration is
+    typically not the one caught here but one of its causes.
+    """
+    seen: set[int] = set()
+    todo: list[BaseException | None] = [exc]
+    while todo:
+        current = todo.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, exception_types):
+            return True
+        todo.append(getattr(current, "source_exception", None))
+        todo.append(current.__cause__)
+    return False
+
+
 def process_advance_block_retry(  # noqa: C901
     state: InterpreterState,
     scope: ScopeType,
@@ -550,6 +614,7 @@ def process_advance_block_retry(  # noqa: C901
     # Extract and evaluate retry configuration
     retry_config = None
     evaluated_retry_config = None
+    retry_exception_types: tuple[type[BaseException], ...] | None = None
     if isinstance(block.retry, RetryConfiguration):
         # Evaluate each field of the retry configuration
         tries, tries_trace = process_expr(
@@ -575,6 +640,11 @@ def process_advance_block_retry(  # noqa: C901
         exceptions, exceptions_trace = process_expr(
             scope, block.retry.exceptions, append(loc, "retry.exceptions")
         )
+        # Resolve the exceptions eagerly so that an invalid exception is
+        # reported even if the block does not fail
+        retry_exception_types = resolve_exception_types(
+            exceptions, append(loc, "retry.exceptions")
+        )
 
         # Create evaluated retry configuration for use
         retry_config = RetryConfiguration(
@@ -582,8 +652,8 @@ def process_advance_block_retry(  # noqa: C901
             delay=delay,
             max_delay=max_delay,
             backoff=backoff,
-            jitter=jitter,
-            exceptions=exceptions,  # pyright: ignore
+            jitter=jitter,  # type: ignore[arg-type] # pyright: ignore
+            exceptions=exceptions,  # type: ignore[arg-type] # pyright: ignore
         )
 
         # Create traced retry configuration for saving in trace
@@ -592,8 +662,8 @@ def process_advance_block_retry(  # noqa: C901
             delay=delay_trace,
             max_delay=max_delay_trace,
             backoff=backoff_trace,
-            jitter=jitter_trace,
-            exceptions=exceptions_trace,
+            jitter=jitter_trace,  # type: ignore[arg-type] # pyright: ignore
+            exceptions=exceptions_trace,  # type: ignore[arg-type] # pyright: ignore
         )
 
         max_retry = tries
@@ -712,54 +782,10 @@ def process_advance_block_retry(  # noqa: C901
             raise exc from exc
         except Exception as exc:
             # Check if the exception matches the configured exception types
-            should_retry_exception = True
-            if retry_config is not None:
-                # Get the exception types to catch
-                exception_types = retry_config.exceptions
-
-                # Convert string names to actual exception classes
-                def resolve_exception_type(exc_type):
-                    if isinstance(exc_type, str):
-                        # Try to get the exception class from builtins
-                        try:
-                            return getattr(__builtins__, exc_type)
-                        except (AttributeError, TypeError):
-                            # If not in builtins, return Exception as fallback
-                            return Exception
-                    return exc_type
-
-                # Normalize to tuple for isinstance check
-                resolved_types: tuple[type[Exception], ...]
-                if isinstance(exception_types, list):
-                    resolved_list = [
-                        resolve_exception_type(e)
-                        for e in exception_types  # pylint: disable=not-an-iterable
-                    ]
-                    # Type assertion to help type checkers
-                    assert all(
-                        isinstance(t, type) and issubclass(t, Exception)
-                        for t in resolved_list
-                    ), "All resolved types must be Exception subclasses"
-                    resolved_types = tuple(resolved_list)  # type: ignore[assignment]
-                elif not isinstance(exception_types, tuple):
-                    resolved_single = resolve_exception_type(exception_types)
-                    assert isinstance(resolved_single, type) and issubclass(
-                        resolved_single, Exception
-                    ), "Resolved type must be an Exception subclass"
-                    resolved_types = (resolved_single,)  # type: ignore[assignment]
-                else:
-                    resolved_list = [
-                        resolve_exception_type(e)
-                        for e in exception_types  # pylint: disable=not-an-iterable
-                    ]
-                    assert all(
-                        isinstance(t, type) and issubclass(t, Exception)
-                        for t in resolved_list
-                    ), "All resolved types must be Exception subclasses"
-                    resolved_types = tuple(resolved_list)  # type: ignore[assignment]
-
-                # Check if the caught exception matches any of the specified types
-                should_retry_exception = isinstance(exc, resolved_types)
+            if retry_exception_types is None:
+                should_retry_exception = True
+            else:
+                should_retry_exception = exception_matches(exc, retry_exception_types)
 
             # Determine if we should retry based on exception match and retry availability
             do_retry = (
@@ -815,6 +841,8 @@ def process_advance_block_retry(  # noqa: C901
                     trace=trace,
                 )
                 result = lazy_apply(checker, result)
+            # The fallback has been executed, no need to try again
+            break
         trial_idx += 1
     state.score.ref += score
     return result, background, new_scope, trace
@@ -1726,6 +1754,7 @@ def process_blocks(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 message=exc.message,
                 blocks=trace,
                 loc=exc.loc or new_loc,
+                source_exception=exc,
             ) from exc
     else:
         iteration_state = state.with_yield_result(

--- a/src/pdl/pdl_openai.py
+++ b/src/pdl/pdl_openai.py
@@ -49,7 +49,10 @@ class OpenaiModel:
     @staticmethod
     def _get_client(config: dict[str, Any]):
         """Create and return an OpenAI client with the given configuration."""
-        from openai import OpenAI
+        # `openai` is an optional dependency, so it is not always resolvable by
+        # the linters. `import-error` is disabled globally in `pylintrc` for the
+        # same reason.
+        from openai import OpenAI  # pylint: disable=no-name-in-module
 
         return OpenAI(**config)
 

--- a/tests/test_retry_exception_filtering.py
+++ b/tests/test_retry_exception_filtering.py
@@ -3,6 +3,8 @@
 import io
 from contextlib import redirect_stderr, redirect_stdout
 
+import pytest
+
 from pdl.pdl import exec_dict
 from pdl.pdl_ast import PDLRuntimeError
 
@@ -70,7 +72,7 @@ def test_retry_with_specific_exception_no_match():
             exception_raised = True
         err_msg = buf.getvalue()
 
-    # Should NOT see retry message since KeyError doesn't match ValueError
+    # Should NOT see retry message since RuntimeError doesn't match ValueError
     assert "[Retry" not in err_msg
     # Exception should be raised immediately
     assert exception_raised
@@ -135,7 +137,7 @@ def test_retry_with_exception_list_no_match():
     with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
         try:
             _ = exec_dict(data)
-        except TypeError:
+        except PDLRuntimeError:
             exception_raised = True
         err_msg = buf.getvalue()
 
@@ -268,6 +270,94 @@ def test_retry_with_fallback_and_exception_filter():
     # When exception doesn't match, it should go to fallback
     result = exec_dict(data)
     assert result == "fallback result"
+
+
+def test_fallback_is_executed_only_once():
+    """Test that the fallback is not re-executed for the remaining attempts."""
+    data = {
+        "description": "Test that the fallback runs once",
+        "text": [
+            {
+                "lang": "python",
+                "code": {
+                    "text": [
+                        "raise TypeError('test exception')\n",
+                        "result = 'success'",
+                    ]
+                },
+            },
+        ],
+        "retry": {
+            "tries": 3,
+            "exceptions": "ValueError",  # Does not match, so the fallback is used
+        },
+        "fallback": {
+            "text": "fallback result",
+        },
+    }
+
+    # `yield_result` streams the result of each executed block, so the fallback
+    # would show up once per attempt if it were executed more than once.
+    out_msg = ""
+    with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
+        result = exec_dict(data, config={"yield_result": True})
+        out_msg = buf.getvalue()
+
+    assert result == "fallback result"
+    assert out_msg.count("fallback result") == 1
+
+
+def test_retry_with_unknown_exception_name():
+    """Test that an exception name that cannot be resolved is reported."""
+    data = {
+        "description": "Test unknown exception name",
+        "text": [
+            {
+                "lang": "python",
+                "code": {"text": ["result = 'success'"]},
+            },
+        ],
+        "retry": {
+            "tries": 2,
+            "exceptions": "NoSuchExceptionName",
+        },
+    }
+
+    # The error is reported even though the block itself does not fail
+    with pytest.raises(PDLRuntimeError, match="Invalid exception"):
+        _ = exec_dict(data)
+
+
+def test_retry_with_exception_matching_python_class():
+    """Test that exceptions can be given as Python exception classes."""
+    data = {
+        "description": "Test exception given as a class",
+        "text": [
+            {
+                "lang": "python",
+                "code": {
+                    "text": [
+                        "raise ValueError('test exception')\n",
+                        "result = 'success'",
+                    ]
+                },
+            },
+        ],
+        "retry": {
+            "tries": 2,
+            "exceptions": "${ exceptions }",
+        },
+    }
+
+    err_msg = ""
+    with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
+        try:
+            _ = exec_dict(data, scope={"exceptions": ValueError})
+        except Exception:  # pylint: disable=broad-except
+            pass
+        err_msg = buf.getvalue()
+
+    assert "[Retry 1/2]" in err_msg
 
 
 # Made with Bob


### PR DESCRIPTION
The retry exception filtering introduced in this branch did not work:

- `getattr(__builtins__, name)` never resolved an exception name. Inside an imported module `__builtins__` is a dict, not a module, so the lookup always raised and silently fell back to `Exception`, which matches everything. Every block therefore retried on any error, and a typo in an exception name was indistinguishable from a correct one. Exceptions are now resolved against the `builtins` and `pdl_ast` modules, eagerly, so that an unknown name is reported even when the block does not fail.

- A list of exception names did not type check: `exceptions` allowed `list[Type[Exception]]` but not `list[str]`, so `exceptions: [ValueError, KeyError]` was rejected by the schema at parse time.

- The exception raised by a block is wrapped in `PDLRuntimeError`s as it propagates, so matching the caught exception directly could never match the exception the user asked for. Matching now walks the wrapped exceptions, and `PDLRuntimeProcessBlocksError` forwards `source_exception` so the chain is not broken halfway.

- The fallback was replayed once per remaining attempt when filtering rejected an exception, because the retry loop kept iterating after running it. This could not happen before filtering existed, as the fallback was only ever reached on the last attempt.

Also regenerate `pdl-schema.json` and `pdl_ast.d.ts`, which had not been updated for `RetryConfiguration` and so rejected the new `retry` object form (caught by test_schema.py).


Claude-Session: https://claude.ai/code/session_014vJFZECENeqPT7Xz1zevkz