### PR TITLE
fix: format generated pdl_ast.d.ts with prettier

### DIFF
--- a/pdl-live-react/src/pdl_ast.d.ts
+++ b/pdl-live-react/src/pdl_ast.d.ts
@@ -117,7 +117,9 @@ export type ContributeTarget = "result" | "context" | "stdout" | "stderr"
  */
 export type Contribute = ContributeElement[]
 export type ParserType =
-  ("json" | "jsonl" | "yaml" | "csv") | PdlParser | RegexParser
+  | ("json" | "jsonl" | "yaml" | "csv")
+  | PdlParser
+  | RegexParser
 export type Regex = string
 export type Mode = "search" | "match" | "fullmatch" | "split" | "findall"
 /**


### PR DESCRIPTION
The regenerated TypeScript types for the new retry configuration were committed without running prettier, so `ParserType` kept the collapsed union form. `npm test` in the viewer runs `prettier --check`, which failed the "Test PDL live viewer" job.

Reformatting only touches `ParserType`; the result is byte-identical to re-running `npm run types` (json2ts + prettier) against the current pdl-schema.json.


Claude-Session: https://claude.ai/code/session_01BAodR9DdrkWrrdSUWU6VkN