### PR TITLE
ci: cancel superseded runs of the PDL example execution tests

### DIFF
--- a/.github/workflows/run-examples-prep.yml
+++ b/.github/workflows/run-examples-prep.yml
@@ -1,6 +1,12 @@
 ---
 name: Run examples on modified PDL files
 on: [pull_request]
+
+# cancel any prior runs for this workflow and this PR (or branch)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Execution tests


### PR DESCRIPTION
The "Run examples on modified PDL files" workflow was the only pull_request-triggered workflow without a concurrency group, so every push to a PR stacked another full example-execution run (~10 minutes, including an Ollama install and model pull, across three Python versions) on top of the ones already in flight.

Add the same concurrency group the other PR workflows already use (Build, Viewer Tests, Rust interpreter, Tauri CLI) so a new push supersedes the previous run instead of racing it.


Claude-Session: https://claude.ai/code/session_01CcKQNiYrUN3xGjzTTC9TS5