### PR TITLE
fix: do not expand iterators when serializing a trace

### DIFF
--- a/src/pdl/pdl_dumper.py
+++ b/src/pdl/pdl_dumper.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import re
-from typing import Any, Iterable, Mapping, Sequence, TypeAlias
+from typing import Any, Iterable, Iterator, Mapping, Sequence, TypeAlias
 
 import yaml
 from pydantic.main import BaseModel, IncEx
@@ -542,7 +542,12 @@ def as_json(value: Any) -> JsonType:
         return value
     if isinstance(value, dict):
         return {str(k): as_json(v) for k, v in value.items()}
-    if isinstance(value, Iterable):
+    # Iterators (generators, `itertools` counters, file handles, ...) are
+    # excluded: they are consumed by iterating over them, so expanding one here
+    # would mutate the state of the running program, and it would never
+    # terminate for an infinite iterator such as `itertools.count()`. They are
+    # rendered as a string by the last case.
+    if isinstance(value, Iterable) and not isinstance(value, Iterator):
         return [as_json(v) for v in value]
     if isinstance(value, Block):
         return as_json(block_to_dict(value, json_compatible=True))  # pyright: ignore

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,11 +1,19 @@
+import itertools
 import pathlib
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
+from pdl.pdl import exec_str
 from pdl.pdl_ast import BlockType, IncludeBlock
 from pdl.pdl_ast_utils import iter_block_children
-from pdl.pdl_dumper import dump_program_exclude_internals, dump_yaml, program_to_dict
+from pdl.pdl_dumper import (
+    as_json,
+    dump_program_exclude_internals,
+    dump_yaml,
+    program_to_dict,
+)
 from pdl.pdl_parser import PDLParseError, parse_file, parse_str
+from pdl.pdl_utils import write_trace
 
 
 def has_include(block: BlockType) -> bool:
@@ -86,3 +94,50 @@ def test_dump_exclude_internals() -> None:
         # Consume the iterator so any exception raised in a worker propagates.
         for _ in executor.map(check, pathlib.Path(".").glob("**/*.pdl")):
             pass
+
+
+def test_as_json_does_not_expand_iterators() -> None:
+    """
+    An iterator is consumed by iterating over it, and may be infinite. `as_json`
+    must therefore render it as a string instead of expanding it into a list.
+    """
+
+    counter = itertools.count(1)
+    assert isinstance(as_json(counter), str)
+    # The counter has not been consumed
+    assert next(counter) == 1
+
+    generator = (i for i in range(3))
+    assert isinstance(as_json(generator), str)
+    assert list(generator) == [0, 1, 2]
+
+    # Concrete collections are still expanded
+    assert as_json([1, 2]) == [1, 2]
+    assert as_json((1, 2)) == [1, 2]
+    assert as_json({"a": 1}) == {"a": 1}
+
+
+ITERATOR_IN_SCOPE_PROGRAM = """
+defs:
+  counter:
+    lang: python
+    code: |
+      import itertools
+      result = itertools.count(1)
+text:
+- lang: python
+  code: result = str(next(counter))
+"""
+
+
+def test_write_trace_with_iterator_in_scope(tmp_path: pathlib.Path) -> None:
+    """
+    A program may store an iterator in a variable. Writing the trace used to
+    expand it, which never terminates for an infinite iterator.
+    """
+
+    output = exec_str(ITERATOR_IN_SCOPE_PROGRAM, output="all")
+    assert output["result"] == "1"
+    trace_file = tmp_path / "trace.json"
+    write_trace(trace_file, output["trace"])
+    assert trace_file.read_text(encoding="utf-8") != ""


### PR DESCRIPTION
`as_json` expanded any `Iterable` into a list. An iterator is consumed by iterating over it, so serializing a trace mutated the state of the running program -- and for an infinite iterator it never terminated.

The three new retry examples store an `itertools.count()` in a variable, so `write_trace` allocated until the process was OOM-killed. That is what fails the "Run examples on modified PDL files / Execution tests" job: the test harness calls `pdl.write_trace` on every example it runs, and the kill takes down the whole pytest process, not just that example.

Skip iterators in `as_json` and fall through to the existing string rendering. Concrete collections (lists, tuples, sets) are still expanded.


Claude-Session: https://claude.ai/code/session_01CLEVG9Gng5CREzBvFfYSPW