### PR TITLE
fix: support unhashable categorical values

### DIFF
--- a/src/pdl/pdl_distributions.py
+++ b/src/pdl/pdl_distributions.py
@@ -28,14 +28,22 @@ class Categorical(Generic[T]):
         """
         Create an equivalent distribution without duplicated values.
         """
-        res: dict[T, tuple[float, list]] = {}
+        values: list[T] = []
+        probs: list[float] = []
+        metadata: list[list[Any]] = []
         for v, w, m in zip(self.values, self.probs, self.metadata):
-            if v in res:
-                w_v, m_v = res[v]
-                res[v] = (w_v + w, m_v + m)
+            try:
+                i = values.index(v)
+            except ValueError:
+                values.append(v)
+                probs.append(w)
+                metadata.append(list(m))
             else:
-                res[v] = (w, m)
-        return Categorical([(v, np.log(w), m) for v, (w, m) in res.items()])
+                probs[i] += w
+                metadata[i] = metadata[i] + m
+        return Categorical(
+            [(v, np.log(w), m) for v, w, m in zip(values, probs, metadata)]
+        )
 
     def sample(self) -> T:
         u = rand.rand()

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,0 +1,26 @@
+import pytest
+
+from pdl.pdl_distributions import Categorical
+
+
+@pytest.mark.parametrize("value", [[1, 2], {"answer": 42}])
+def test_categorical_supports_unhashable_values(value):
+    dist = Categorical(
+        [
+            (value, 0.0, ["first"]),
+            (value.copy(), 0.0, ["second"]),
+            (None, 0.0, ["third"]),
+        ]
+    )
+
+    shrunk = dist.shrink()
+    assert shrunk.values == (value, None)
+    assert shrunk.probs == pytest.approx([2 / 3, 1 / 3])
+    assert shrunk.metadata == (["first", "second"], ["third"])
+
+    sorted_dist = dist.sort()
+    assert sorted_dist.values == [value, None]
+    assert sorted_dist.probs == pytest.approx([2 / 3, 1 / 3])
+    assert sorted_dist.metadata == [["first", "second"], ["third"]]
+
+    assert dist.prob(value.copy()) == pytest.approx(2 / 3)


### PR DESCRIPTION
## Summary

- consolidate equal categorical values without requiring hashable results
- preserve combined probabilities and metadata without mutating the source distribution
- test list and dictionary values through `shrink()`, `sort()`, and `prob()`

Fixes #1698

## Testing

- `pytest -q tests/test_distributions.py`
- isort
- Black
- Flake8
- Pylint
- Bandit
- Mypy
