### PR TITLE
Fix selective contributions to built-in targets

### DIFF
--- a/src/pdl/pdl_interpreter.py
+++ b/src/pdl/pdl_interpreter.py
@@ -157,8 +157,8 @@ from .pdl_utils import (
     GeneratorWrapper,
     Resample,
     apply_defaults,
-    get_contribute_context_value,
-    replace_contribute_value,
+    get_contribute_value,
+    has_contribute_target,
     stringify,
     value_of_expr,
     write_trace,
@@ -466,14 +466,28 @@ def process_advanced_block(  # noqa: C901
         var = block.def_
         new_scope = new_scope | PdlDict({var: result})
     new_scope, trace = process_contribute(trace, result, new_scope, loc)
-    if ContributeTarget.CONTEXT.value not in block.contribute:
+    context_value = get_contribute_value(trace.contribute, ContributeTarget.CONTEXT)
+    if not has_contribute_target(block.contribute, ContributeTarget.CONTEXT):
         background = DependentContext([])
-    else:
-        contribute_value, trace = process_contribute_context(trace, new_scope, loc)
-        if contribute_value is not None:
-            background = DependentContext([contribute_value])
-    if ContributeTarget.RESULT.value not in block.contribute:
+    elif context_value is not None:
+        background = SingletonContext(
+            PdlDict(
+                {
+                    "role": state.role,
+                    "content": PdlConst(value_of_expr(context_value.value)),
+                    "pdl__defsite": block.pdl__id,
+                }
+            )
+        )
+        if state.yield_background:
+            yield_background(background)
+    result_value = get_contribute_value(trace.contribute, ContributeTarget.RESULT)
+    if not has_contribute_target(block.contribute, ContributeTarget.RESULT):
         result = PdlConst("")
+    elif result_value is not None:
+        result = PdlConst(value_of_expr(result_value.value))
+        if state.yield_result:
+            yield_result(result.result(), block.kind)
     return result, background, new_scope, trace
 
 
@@ -604,7 +618,7 @@ def process_advance_block_retry(  # noqa: C901
     init_state = state
     state = state.with_yield_result(
         state.yield_result
-        and ContributeTarget.RESULT.value in block.contribute
+        and ContributeTarget.RESULT in block.contribute
         and block.parser is None
     )
     state = state.with_yield_background(
@@ -849,11 +863,7 @@ def process_advance_block_retry(  # noqa: C901
 
 
 def context_in_contribute(block: AdvancedBlockType) -> bool:
-    if ContributeTarget.CONTEXT.value in block.contribute:
-        return True
-    if get_contribute_context_value(block.contribute) is not None:
-        return True
-    return False
+    return ContributeTarget.CONTEXT in block.contribute
 
 
 ResultWithTypeCheckingT = TypeVar("ResultWithTypeCheckingT")
@@ -1805,36 +1815,6 @@ def combine_results(join_type: JoinType, results: list[PdlLazy[Any]]):
     return result
 
 
-BlockTypeTVarProcessContributeOld = TypeVar(
-    "BlockTypeTVarProcessContributeOld", bound=AdvancedBlockType
-)
-
-
-def process_contribute_context(
-    block: BlockTypeTVarProcessContributeOld, scope: ScopeType, loc: PdlLocationType
-) -> tuple[Any, BlockTypeTVarProcessContributeOld]:
-    result: list[ContributeElement]
-    value_trace: LocalizedExpression[list[ContributeElement]]
-    value = get_contribute_context_value(block.contribute)
-    if value is None:
-        return None, block
-    loc = append(loc, "contribute")
-    try:
-        result, value_trace = process_expr(scope, value, loc)
-    except PDLRuntimeExpressionError as exc:
-        raise PDLRuntimeError(
-            exc.message,
-            loc=exc.loc or loc,
-            trace=ErrorBlock(msg=exc.message, pdl__location=loc, program=block),
-            source_exception=exc,
-        ) from exc
-    replace = replace_contribute_value(
-        block.contribute, ContributeValue(value=value_trace)
-    )
-    trace = block.model_copy(update={"contribute": replace})
-    return result, trace
-
-
 BlockTypeTVarProcessContribute = TypeVar(
     "BlockTypeTVarProcessContribute", bound=AdvancedBlockType
 )
@@ -1890,6 +1870,11 @@ def process_contribution(
                     source_exception=exc,
                 ) from exc
             elem = {target: ContributeValue(value=value_trace)}
+            if target in (
+                ContributeTarget.RESULT,
+                ContributeTarget.CONTEXT,
+            ):
+                return scope, elem
         case _:
             msg = "Contributions are expected to be strings or dictionaries of length 1 but got {elem}"
             raise PDLRuntimeError(

--- a/src/pdl/pdl_utils.py
+++ b/src/pdl/pdl_utils.py
@@ -93,31 +93,27 @@ def value_of_expr(expr: ExpressionType[ValueOfExprT]) -> ValueOfExprT:
     return v  # type: ignore
 
 
-def replace_contribute_value(  # TODO: remove
-    contribute: Sequence[ContributeElement],
-    value: ContributeValue,
-):
-    ret = []
-    for item in contribute:
-        if isinstance(item, dict) and isinstance(
-            item[ContributeTarget.CONTEXT], ContributeValue
-        ):
-            item = value
-        ret.append(item)
-    return ret
-
-
-def get_contribute_context_value(
+def get_contribute_value(
     contribute: Sequence[ContributeElement] | None,
-):
+    target: ContributeTarget,
+) -> ContributeValue | None:
     if contribute is None:
         return None
     for item in contribute:
-        if isinstance(item, dict) and isinstance(
-            item.get(ContributeTarget.CONTEXT), ContributeValue
-        ):
-            return item[ContributeTarget.CONTEXT].value
+        if isinstance(item, dict):
+            value = item.get(target)
+            if isinstance(value, ContributeValue):
+                return value
     return None
+
+
+def has_contribute_target(
+    contribute: Sequence[ContributeElement] | None,
+    target: ContributeTarget,
+) -> bool:
+    if contribute is None:
+        return False
+    return target in contribute or get_contribute_value(contribute, target) is not None
 
 
 def message_post_processing(message: dict) -> dict[str, Any]:

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,3 +1,6 @@
+import io
+from contextlib import redirect_stdout
+
 from pdl.pdl import exec_dict, exec_str
 from pdl.pdl_context import SerializeMode
 
@@ -48,6 +51,106 @@ def test_contribute_context():
             "pdl__defsite": "text.0.text.code",
         }
     ]
+
+
+def test_contribute_selective_context():
+    result = exec_str(
+        """
+text:
+- def: STEP
+  text: "FULL-RESULT-BODY"
+  contribute:
+    - result
+    - context:
+        value: "TINY-SUMMARY"
+- "end"
+""",
+        output="all",
+    )
+
+    assert result["result"] == "FULL-RESULT-BODYend"
+    assert result["scope"]["pdl_context"].serialize(SerializeMode.LITELLM) == [
+        {
+            "role": "user",
+            "content": "TINY-SUMMARY",
+            "pdl__defsite": "text.0.text",
+        },
+        {"role": "user", "content": "end", "pdl__defsite": "text.1.data"},
+    ]
+    contribution = result["trace"].text[0].contribute[1]["context"]
+    assert contribution.value.pdl__result == "TINY-SUMMARY"
+
+
+def test_contribute_selective_result():
+    result = exec_str(
+        """
+text: "FULL-RESULT-BODY"
+contribute:
+  - result:
+      value: "TINY-SUMMARY"
+""",
+        output="all",
+    )
+
+    assert result["result"] == "TINY-SUMMARY"
+    assert result["scope"]["pdl_context"].serialize(SerializeMode.LITELLM) == []
+    contribution = result["trace"].contribute[0]["result"]
+    assert contribution.value.pdl__result == "TINY-SUMMARY"
+
+
+def test_contribute_selective_values_are_streamed():
+    selective_result = """
+text: "FULL-RESULT-BODY"
+contribute:
+  - result:
+      value: "TINY-RESULT"
+"""
+    with io.StringIO() as stdout, redirect_stdout(stdout):
+        exec_str(selective_result, config={"yield_result": True})
+        result_output = stdout.getvalue()
+    assert result_output == "TINY-RESULT"
+
+    selective_context = """
+text: "FULL-RESULT-BODY"
+contribute:
+  - context:
+      value: "TINY-CONTEXT"
+"""
+    with io.StringIO() as stdout, redirect_stdout(stdout):
+        exec_str(selective_context, config={"yield_background": True})
+        context_output = stdout.getvalue()
+    assert "TINY-CONTEXT" in context_output
+    assert "FULL-RESULT-BODY" not in context_output
+
+
+def test_contribute_selective_value_to_named_aggregator(tmp_path):
+    log_file = tmp_path / "log.txt"
+    result = exec_str(
+        f"""
+defs:
+  log:
+    aggregator:
+      file: "{log_file.as_posix()}"
+text: "FULL-RESULT-BODY"
+contribute:
+  - result
+  - log:
+      value: "TINY-SUMMARY"
+  - context:
+      value: "TINY-CONTEXT"
+""",
+        output="all",
+    )
+
+    assert result["result"] == "FULL-RESULT-BODY"
+    assert result["scope"]["pdl_context"].serialize(SerializeMode.LITELLM) == [
+        {
+            "role": "user",
+            "content": "TINY-CONTEXT",
+            "pdl__defsite": "text",
+        }
+    ]
+    assert log_file.read_text(encoding="utf-8") == "TINY-SUMMARY\n"
 
 
 def test_contribute_false():


### PR DESCRIPTION
## Summary

- Handle selective `context` and `result` values without looking them up as named aggregators
- Preserve role and definition-site metadata for selective context messages
- Stream selective values instead of the full block values
- Keep contribution traces and named aggregator behavior intact

## Testing

- `pytest tests --ignore=tests/test_examples_run.py -q`
- `pre-commit run --all-files`

Fixes #1687