### PR TITLE
ci: make Viewer Tests resilient to third-party apt repo failures

### DIFF
--- a/.github/workflows/pdl-live-react-tests.yml
+++ b/.github/workflows/pdl-live-react-tests.yml
@@ -24,9 +24,29 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+      - name: Refresh apt indexes
+        # The runner image preconfigures third-party apt repositories (Google
+        # Chrome, Microsoft) that intermittently serve indexes failing with
+        # "Hash Sum mismatch", which aborts `apt update` and therefore also
+        # `playwright install --with-deps`. None of them are needed here
+        # (Playwright downloads its own browsers), so drop them and start from
+        # a clean list cache.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -rf /var/lib/apt/lists/*
+          for i in 1 2 3; do
+            if sudo apt-get update; then
+              exit 0
+            fi
+            echo "apt-get update failed (attempt $i), retrying..."
+            sudo rm -rf /var/lib/apt/lists/*
+            sleep $((i * 5))
+          done
+          exit 1
       - name: Install dependencies
         run: |
-          npm ci & sudo apt update && sudo apt install -y libgtk-3-dev libwebkit2gtk-4.1-dev librsvg2-dev patchelf at-spi2-core
+          npm ci & sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev librsvg2-dev patchelf at-spi2-core
           wait
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/pdl-live-react/package.json
+++ b/pdl-live-react/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write 'tests/**/*.ts' 'src/**/*.{ts,tsx,css}' && (cd src-tauri && cargo fmt)",
     "tauri": "tauri",
     "test:quality": "concurrently -n 'lint,types,formatting' 'npm run lint' 'tsc --build --noEmit' \"prettier --check 'tests/**/*.ts'  'src/**/*.{ts,tsx,css}'\"",
-    "test:ui": "playwright install --with-deps && playwright test",
+    "test:ui": "playwright install && playwright test",
     "test:bee": "until [ -f ./src-tauri/target/debug/pdl ]; do sleep 1; done; for i in ./demos/beeai/*.py; do ./src-tauri/target/debug/pdl compile beeai $i -g --output - | jq; done",
     "test:interpreter": "cd src-tauri && cargo test",
     "types": "(cd .. && python -m src.pdl.pdl --schema > src/pdl/pdl-schema.json) && json2ts ../src/pdl/pdl-schema.json src/pdl_ast.d.ts --unreachableDefinitions && npm run format",


### PR DESCRIPTION
`npx playwright install --with-deps` runs `apt-get update`, which aborts when the runner image's preconfigured Google Chrome apt repository serves an index that fails verification ("Hash Sum mismatch"), failing the job before any test runs.

Add a step that removes the third-party apt sources (unnecessary here, since Playwright downloads its own browsers), clears the stale list cache, and retries `apt-get update` a few times before giving up. The subsequent dependency install now reuses those refreshed indexes instead of running its own `apt update`.

Also drop `--with-deps` from the `test:ui` npm script so `npm test` does not trigger a second, redundant apt run inside the test step; CI already installs the system dependencies in its dedicated Playwright step.


Claude-Session: https://claude.ai/code/session_01UtCknujN3jj722jTxDhcp7