### PR TITLE
fix(deps): clear all RustSec advisories in the Tauri app and gate on cargo audit

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,64 @@
+name: Rust Dependency Audit
+
+# Checks the Tauri app's Cargo.lock against the RustSec advisory database.
+#
+# `cargo audit` fails the job on *vulnerabilities* only. Informational
+# advisories (unmaintained, unsound, yanked) are reported but do not fail the
+# build, since many of them have no fixed version to upgrade to. Advisories we
+# have deliberately accepted are listed, with justification, in
+# pdl-live-react/src-tauri/.cargo/audit.toml.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'pdl-live-react/src-tauri/Cargo.toml'
+      - 'pdl-live-react/src-tauri/Cargo.lock'
+      - 'pdl-live-react/src-tauri/.cargo/audit.toml'
+      - '.github/workflows/cargo-audit.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'pdl-live-react/src-tauri/Cargo.toml'
+      - 'pdl-live-react/src-tauri/Cargo.lock'
+      - 'pdl-live-react/src-tauri/.cargo/audit.toml'
+      - '.github/workflows/cargo-audit.yml'
+  # Advisories are published without us touching the lockfile, so also check on
+  # a schedule rather than only when the dependencies change.
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# cancel any prior runs for this workflow and this PR (or branch)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: Audit Rust dependencies
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # so that `cargo audit` picks up both Cargo.lock and .cargo/audit.toml
+        working-directory: ./pdl-live-react/src-tauri
+    steps:
+      - uses: actions/checkout@v6
+      # Building cargo-audit from source takes a few minutes, so cache the
+      # binary. The key rotates monthly so that we still pick up new releases of
+      # the tool itself; the advisory database is fetched fresh on every run.
+      - name: Compute cache key
+        id: cache-key
+        run: echo "month=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"
+      - name: Cache cargo-audit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-${{ steps.cache-key.outputs.month }}
+      - name: Install cargo-audit
+        run: which cargo-audit || cargo install cargo-audit --locked
+      - name: Audit
+        run: cargo audit

--- a/pdl-live-react/src-tauri/.cargo/audit.toml
+++ b/pdl-live-react/src-tauri/.cargo/audit.toml
@@ -4,6 +4,9 @@
 #
 #     cargo audit
 #
+# CI runs the same command from this directory, see
+# .github/workflows/cargo-audit.yml.
+#
 # Every entry in `ignore` below must carry a justification and, where it
 # applies, the condition under which it can be removed again.
 

--- a/pdl-live-react/src-tauri/.cargo/audit.toml
+++ b/pdl-live-react/src-tauri/.cargo/audit.toml
@@ -1,0 +1,41 @@
+# Configuration for `cargo audit` (https://github.com/rustsec/rustsec).
+#
+# Run it from this directory:
+#
+#     cargo audit
+#
+# Every entry in `ignore` below must carry a justification and, where it
+# applies, the condition under which it can be removed again.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2024-0429 / GHSA-wrw7-89jp-8q8g
+    # "Unsoundness in `Iterator` and `DoubleEndedIterator` impls for
+    # `glib::VariantStrIter`" (informational: unsound, not a vulnerability).
+    #
+    # Why it is not fixable by an upgrade:
+    #   The advisory is only patched in glib >= 0.20 (the fix also landed on
+    #   the 0.19 branch), but we cannot reach either version. glib is a
+    #   transitive, Linux-only dependency of the Tauri desktop app:
+    #
+    #       tauri -> wry/tao -> gtk 0.18 -> glib ^0.18
+    #
+    #   gtk3-rs 0.18 requires `glib ^0.18`, and 0.18.5 is the last 0.18
+    #   release, so no semver-compatible fixed version exists. The `gtk`
+    #   crate only moved off glib 0.18 in 0.19.0, and no released version of
+    #   `wry` or `tao` depends on `gtk` 0.19 yet, so every Tauri 2 app on
+    #   Linux currently resolves to glib 0.18.x.
+    #
+    # Why the impact here is nil:
+    #   The unsound code is `VariantStrIter::impl_get`, reachable only
+    #   through the public `glib::Variant::array_iter_str()` API. Neither
+    #   this crate nor any crate in the GTK/Tauri dependency tree (gio, gtk,
+    #   gdk, gdkx11, atk, pango, soup3, javascriptcore-rs, webkit2gtk,
+    #   libappindicator, tao, wry, tauri, muda, tray-icon) calls
+    #   `array_iter_str` or constructs a `VariantStrIter`, so the affected
+    #   functions are never instantiated in our builds.
+    #
+    # Remove this entry once `wry`/`tao` move to `gtk` >= 0.19 (glib >= 0.22)
+    # and a `cargo update` pulls glib >= 0.20 into Cargo.lock.
+    "RUSTSEC-2024-0429",
+]

--- a/pdl-live-react/src-tauri/Cargo.lock
+++ b/pdl-live-react/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arraydeque"
@@ -374,9 +374,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -384,14 +384,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -405,6 +406,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -973,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1494,11 +1501,10 @@ checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3889,11 +3895,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
+checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "indexmap 2.14.0",
  "quick-xml",
  "serde",
@@ -4068,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -4567,7 +4573,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4598,11 +4604,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -4623,7 +4630,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4634,9 +4641,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6095,10 +6102,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
`cargo audit` reported 7 vulnerabilities in `pdl-live-react/src-tauri/Cargo.lock`. All are fixable with semver-compatible updates, so this is a lockfile-only change plus a CI gate to keep it that way.

### Vulnerabilities fixed

| Crate | Before → After | Advisories |
| --- | --- | --- |
| `rustls-webpki` | 0.103.3 → 0.103.15 | RUSTSEC-2026-0049, -0098, -0099, -0104 |
| `quick-xml` | 0.32.0 → 0.42.0 | RUSTSEC-2026-0194, -0195 (7.5 high) |
| `crossbeam-epoch` | 0.9.18 → 0.9.21 | RUSTSEC-2026-0204 |

`quick-xml` is only reachable through `plist`, which needed 1.7.1 → 1.10.1 to pick up `quick-xml` >= 0.41. `rustls-webpki` >= 0.103.8 requires `rustls-pki-types` >= 1.12, which pulls in the `aws-lc-rs` / `aws-lc-sys` bumps.

Also takes two semver-compatible fixes for `unsound` advisories that were only reported as warnings: `anyhow` 1.0.98 → 1.0.104 (RUSTSEC-2026-0190) and `event-listener` 5.4.0 → 5.4.2 (RUSTSEC-2026-0221).

### RUSTSEC-2024-0429 (`glib`), documented rather than fixed

This one cannot be fixed by an upgrade. `glib` is a transitive, Linux-only dependency via `tauri → wry/tao → gtk 0.18 → glib ^0.18`, and 0.18.5 is the last release of the 0.18 line — the advisory is only fixed in glib >= 0.19.9 / 0.20. `gtk` moved off glib 0.18 in 0.19.0, but no released `wry` or `tao` depends on `gtk` 0.19 yet, so `cargo update -p glib` is a no-op.

The affected code is also unreachable here: `VariantStrIter::impl_get` is only reachable through `glib::Variant::array_iter_str()`, and neither this crate nor any crate in the GTK/Tauri dependency tree calls it.

It is therefore ignored in a new `src-tauri/.cargo/audit.toml`, with that rationale and the condition for removing the entry again recorded inline.

### CI gate

New `.github/workflows/cargo-audit.yml` scans the lockfile against the RustSec database on pushes/PRs touching `Cargo.toml`, `Cargo.lock` or the audit config, weekly on a schedule (advisories get published without the lockfile changing), and on demand.

`cargo audit` fails only on vulnerabilities; informational advisories (unmaintained, unsound, yanked) are reported without failing the build, which is what we want since several currently carried have no fixed version. It runs from `src-tauri` so it picks up `.cargo/audit.toml`. The `cargo-audit` binary is cached with a monthly-rotating key so new releases of the tool are still picked up.

### Verification

- `cargo audit`: 7 vulnerabilities → 0.
- `cargo check --all-targets`: passes (only pre-existing dead-code warnings).
- `cargo check --features interpreter`: passes (only pre-existing naming warnings).
- Gate has teeth: exit 1 against the pre-fix lockfile, exit 0 against this one.

### Known remaining, not fixable by upgrade

`memmap2` 0.5.10 (unsound, pinned by `rustpython-stdlib`, a git dep behind the optional `interpreter` feature); 13 unmaintained crates (`unic-*`, `paste`, `proc-macro-error` — no fixed versions exist); `chacha20` 0.10.1 flagged yanked. All informational warnings, none vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvjGt7TbcU6eV5qWhNCE7j